### PR TITLE
feat: sync overnight HRV from Mi sleep payloads

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.health.WRITE_BODY_TEMPERATURE" />
     <uses-permission android:name="android.permission.health.WRITE_SKIN_TEMPERATURE" />
     <uses-permission android:name="android.permission.health.WRITE_VO2_MAX" />
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
 
     <!-- Optional reads (future verification / UI) -->
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />

--- a/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
@@ -13,6 +13,7 @@ import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ElevationGainedRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
@@ -35,6 +36,7 @@ import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SpO2Sample
 import com.bettermifitness.sync.data.api.StepsRecord
@@ -73,6 +75,7 @@ actual class HealthWriter(private val context: Context) : HealthStore {
             HealthPermission.getWritePermission(BloodPressureRecord::class),
             HealthPermission.getWritePermission(BodyTemperatureRecord::class),
             HealthPermission.getWritePermission(Vo2MaxRecord::class),
+            HealthPermission.getWritePermission(HeartRateVariabilityRmssdRecord::class),
         )
         val skinOk = try {
             client.features.getFeatureStatus(HealthConnectFeatures.FEATURE_SKIN_TEMPERATURE) ==
@@ -379,6 +382,24 @@ actual class HealthWriter(private val context: Context) : HealthStore {
                 metadata = Metadata.manualEntry(
                     clientRecordId = HealthRecordIds.vo2Max(s.timestamp),
                     clientRecordVersion = HealthRecordIds.version(s.timestamp, s.mlPerKgMin),
+                ),
+            )
+        }
+        client.insertRecords(records)
+    }
+
+    actual override suspend fun writeHrv(samples: List<HrvSample>) {
+        val clean = HealthDataNormalizer.normalizeHrv(samples)
+        if (clean.isEmpty()) return
+        // Mi overnight HRV is in ms; Health Connect stores RMSSD milliseconds.
+        val records = clean.map { s ->
+            HeartRateVariabilityRmssdRecord(
+                time = Instant.ofEpochSecond(s.timestamp),
+                zoneOffset = ZoneOffset.UTC,
+                heartRateVariabilityMillis = s.hrvMs,
+                metadata = Metadata.manualEntry(
+                    clientRecordId = HealthRecordIds.hrv(s.timestamp),
+                    clientRecordVersion = HealthRecordIds.version(s.timestamp, s.hrvMs),
                 ),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/Models.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/Models.kt
@@ -71,6 +71,15 @@ data class SleepSession(
     val inBedStart: Long = 0,
     val inBedEnd: Long = 0,
     val stages: List<SleepStage> = emptyList(),
+    /**
+     * Overnight HRV from Mi sleep payload (ms). Present only on capable devices
+     * (e.g. Band 10 Pro); Band 10 and similar omit these fields.
+     */
+    val avgHrvMs: Int? = null,
+    val minHrvMs: Int? = null,
+    val maxHrvMs: Int? = null,
+    /** Epoch seconds when Mi analyzed HRV; falls back to wake time when writing. */
+    val hrvAnalysisTimeSec: Long? = null,
 )
 
 @Serializable
@@ -78,6 +87,17 @@ data class SleepStage(
     val startTime: Long,
     val endTime: Long,
     val stage: Int, // 2=light/core, 3=deep, 4=REM, 5=awake (Mi codes)
+)
+
+/**
+ * Overnight HRV sample derived from Mi sleep JSON (`avg_hrv` in ms).
+ * Not a separate Mi cloud key — only written when sleep payload includes HRV.
+ */
+@Serializable
+data class HrvSample(
+    val timestamp: Long,
+    /** Heart-rate variability in milliseconds (Mi UI unit). */
+    val hrvMs: Double,
 )
 
 // --- Steps ---

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/parse/MiFitnessParsers.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/parse/MiFitnessParsers.kt
@@ -6,6 +6,7 @@ import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateEntry
 import com.bettermifitness.sync.data.api.HeartRateSample
 // HeartRateSample used by heartRateInWindow
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepEntry
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SleepStage
@@ -48,6 +49,10 @@ fun SleepEntry.toRaw(): RawFitnessEntry = RawFitnessEntry(key, time, value)
 object MiFitnessParsers {
 
     private val json = Json { ignoreUnknownKeys = true }
+
+    /** Plausible overnight wrist HRV in milliseconds (Mi UI unit). */
+    private const val HRV_MS_MIN = 5
+    private const val HRV_MS_MAX = 300
 
     fun parseHeartRateSamples(entries: List<RawFitnessEntry>): List<HeartRateSample> =
         entries.mapNotNull { entry ->
@@ -350,6 +355,28 @@ object MiFitnessParsers {
         }
     }
 
+    private fun JsonObject.intField(name: String): Int? {
+        val el = this[name] ?: return null
+        return try {
+            el.jsonPrimitive.intOrNull
+                ?: el.jsonPrimitive.doubleOrNull?.toInt()
+                ?: el.jsonPrimitive.content.toIntOrNull()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun JsonObject.longField(name: String): Long? {
+        val el = this[name] ?: return null
+        return try {
+            el.jsonPrimitive.longOrNull
+                ?: el.jsonPrimitive.doubleOrNull?.toLong()
+                ?: el.jsonPrimitive.content.toLongOrNull()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     /** Rough elevation gain from min/max when Mi does not send ascent explicitly. */
     private fun elevationGain(minH: Double?, maxH: Double?, avgH: Double?): Double? {
         if (minH != null && maxH != null && maxH > minH && maxH != 0.0) {
@@ -402,19 +429,51 @@ object MiFitnessParsers {
                 )
             }
 
+            val endTime = obj["wake_up_time"]?.jsonPrimitive?.long ?: entry.time
+            val avgHrv = obj.intField("avg_hrv")
+                ?: obj.intField("avgHrv")
+            val minHrv = obj.intField("min_hrv")
+                ?: obj.intField("minHrv")
+            val maxHrv = obj.intField("max_hrv")
+                ?: obj.intField("maxHrv")
+            val hrvAnalysis = obj.longField("hrv_analysis_timestamp")
+                ?: obj.longField("hrvAnalysisTimestamp")
+
             SleepSession(
                 startTime = obj["bedtime"]?.jsonPrimitive?.long ?: entry.time,
-                endTime = obj["wake_up_time"]?.jsonPrimitive?.long ?: entry.time,
+                endTime = endTime,
                 inBedStart = obj["bed_timestamp"]?.jsonPrimitive?.long
                     ?: obj["bedtime"]?.jsonPrimitive?.long ?: entry.time,
                 inBedEnd = obj["out_bed_timestamp"]?.jsonPrimitive?.long
                     ?: obj["wake_up_time"]?.jsonPrimitive?.long ?: entry.time,
                 stages = stages,
+                avgHrvMs = avgHrv,
+                minHrvMs = minHrv,
+                maxHrvMs = maxHrv,
+                hrvAnalysisTimeSec = hrvAnalysis,
             )
         } catch (_: Exception) {
             null
         }
     }
+
+    /**
+     * Overnight HRV samples from sleep payloads.
+     * Devices without HRV simply omit `avg_hrv` — returns empty (not an error).
+     */
+    fun parseHrvSamples(entries: List<RawFitnessEntry>): List<HrvSample> =
+        hrvSamplesFromSessions(parseSleepSessions(entries))
+
+    fun hrvSamplesFromSessions(sessions: List<SleepSession>): List<HrvSample> =
+        sessions.mapNotNull { session ->
+            val ms = session.avgHrvMs ?: return@mapNotNull null
+            if (ms !in HRV_MS_MIN..HRV_MS_MAX) return@mapNotNull null
+            val t = session.hrvAnalysisTimeSec
+                ?.takeIf { it > 0 }
+                ?: session.endTime.takeIf { it > 0 }
+                ?: return@mapNotNull null
+            HrvSample(timestamp = t, hrvMs = ms.toDouble())
+        }
 
     /**
      * Insert explicit awake stages for gaps ≥ 60s between reported sleep stages.

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/SyncPreferences.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/SyncPreferences.kt
@@ -93,6 +93,7 @@ class SyncPreferences(
             "heart_rate",
             "resting_heart_rate",
             "sleep",
+            "hrv",
             "steps",
             "distance",
             "active_calories",

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
@@ -16,6 +16,7 @@ data class SyncProgress(
     val heartRate: SyncState = SyncState.Idle,
     val restingHeartRate: SyncState = SyncState.Idle,
     val sleep: SyncState = SyncState.Idle,
+    val hrv: SyncState = SyncState.Idle,
     val steps: SyncState = SyncState.Idle,
     val distance: SyncState = SyncState.Idle,
     val activeCalories: SyncState = SyncState.Idle,
@@ -64,6 +65,8 @@ class HealthRepository(
         if ("heart_rate" in enabled) syncHeartRate(from, to)
         if ("resting_heart_rate" in enabled) syncRestingHeartRate(from, to)
         if ("sleep" in enabled) syncSleep(from, to)
+        // HRV is derived from sleep payloads (no separate Mi key); empty = non-capable device.
+        if ("hrv" in enabled) syncHrv(from, to)
         if ("steps" in enabled) syncSteps(from, to)
         if ("distance" in enabled) syncDistance(from, to)
         if ("active_calories" in enabled) syncActiveCalories(from, to)
@@ -111,6 +114,21 @@ class HealthRepository(
             )
             if (sessions.isNotEmpty()) healthWriter.writeSleep(sessions)
             sessions.size
+        }
+    }
+
+    /**
+     * Overnight HRV from sleep JSON (`avg_hrv`). Uses the same `sleep` cloud key —
+     * devices without HRV simply yield 0 samples (success).
+     */
+    suspend fun syncHrv(from: String, to: String) {
+        runMetric("hrv") {
+            val response = api.getLatest("sleep", limit = 30)
+            val samples = MiFitnessParsers.parseHrvSamples(
+                response.result?.dataList.orEmpty().map { it.toRaw() },
+            )
+            if (samples.isNotEmpty()) healthWriter.writeHrv(samples)
+            samples.size
         }
     }
 
@@ -337,6 +355,7 @@ class HealthRepository(
             "heartRate" -> _syncProgress.value.copy(heartRate = state)
             "restingHeartRate" -> _syncProgress.value.copy(restingHeartRate = state)
             "sleep" -> _syncProgress.value.copy(sleep = state)
+            "hrv" -> _syncProgress.value.copy(hrv = state)
             "steps" -> _syncProgress.value.copy(steps = state)
             "distance" -> _syncProgress.value.copy(distance = state)
             "activeCalories" -> _syncProgress.value.copy(activeCalories = state)

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/SyncRunResult.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/SyncRunResult.kt
@@ -71,6 +71,7 @@ fun SyncProgress.stateForKey(key: String): SyncState? = when (key) {
     "heart_rate" -> heartRate
     "resting_heart_rate" -> restingHeartRate
     "sleep" -> sleep
+    "hrv" -> hrv
     "steps" -> steps
     "distance" -> distance
     "active_calories" -> activeCalories

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
@@ -4,6 +4,7 @@ import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SleepStage
 import com.bettermifitness.sync.data.api.SpO2Sample
@@ -101,6 +102,12 @@ object HealthDataNormalizer {
                 inBedStart = inBedStart,
                 inBedEnd = inBedEnd,
                 stages = stages,
+                avgHrvMs = session.avgHrvMs?.takeIf { it in 5..300 },
+                minHrvMs = session.minHrvMs?.takeIf { it in 5..300 },
+                maxHrvMs = session.maxHrvMs?.takeIf { it in 5..300 },
+                hrvAnalysisTimeSec = session.hrvAnalysisTimeSec
+                    ?.let { toEpochSeconds(it) }
+                    ?.takeIf { isPlausibleEpochSeconds(it) },
             )
         }
             .sortedBy { it.startTime }
@@ -108,6 +115,18 @@ object HealthDataNormalizer {
             .values
             .sortedBy { it.startTime }
     }
+
+    fun normalizeHrv(samples: List<HrvSample>): List<HrvSample> =
+        samples.mapNotNull { s ->
+            val t = toEpochSeconds(s.timestamp)
+            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (s.hrvMs !in 5.0..300.0) return@mapNotNull null
+            HrvSample(timestamp = t, hrvMs = s.hrvMs)
+        }
+            .sortedBy { it.timestamp }
+            .associateBy { it.timestamp }
+            .values
+            .sortedBy { it.timestamp }
 
     /**
      * Mi Fitness sleep states → platform-neutral labels for tests.

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthPorts.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthPorts.kt
@@ -4,6 +4,7 @@ import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SpO2Sample
 import com.bettermifitness.sync.data.api.StepsRecord
@@ -28,6 +29,8 @@ interface HealthSampleWriter {
     suspend fun writeBloodPressure(samples: List<BloodPressureSample>)
     suspend fun writeTemperature(samples: List<TemperatureSample>)
     suspend fun writeVo2Max(samples: List<Vo2MaxSample>)
+    /** Overnight HRV (ms). Empty list is a no-op — non-capable devices send no samples. */
+    suspend fun writeHrv(samples: List<HrvSample>)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthRecordIds.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthRecordIds.kt
@@ -66,6 +66,9 @@ object HealthRecordIds {
     fun vo2Max(timestampSec: Long): String =
         "mifit-vo2max-$timestampSec"
 
+    fun hrv(timestampSec: Long): String =
+        "mifit-hrv-$timestampSec"
+
     /** Floor epoch seconds to the HR batch window start. */
     fun heartRateWindowStart(timestampSec: Long): Long =
         (timestampSec / HEART_RATE_WINDOW_SEC) * HEART_RATE_WINDOW_SEC

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthWriter.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthWriter.kt
@@ -4,6 +4,7 @@ import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SpO2Sample
 import com.bettermifitness.sync.data.api.StepsRecord
@@ -29,6 +30,7 @@ expect class HealthWriter : HealthStore {
     override suspend fun writeBloodPressure(samples: List<BloodPressureSample>)
     override suspend fun writeTemperature(samples: List<TemperatureSample>)
     override suspend fun writeVo2Max(samples: List<Vo2MaxSample>)
+    override suspend fun writeHrv(samples: List<HrvSample>)
     override suspend fun isAvailable(): Boolean
     override suspend fun hasWritePermissions(): Boolean
     override suspend fun requestPermissions()

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/SyncMetric.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/SyncMetric.kt
@@ -12,6 +12,8 @@ enum class SyncMetric(
     HEART_RATE("heart_rate", "Heart Rate", AppIcons.MonitorHeart),
     RESTING_HEART_RATE("resting_heart_rate", "Resting Heart Rate", AppIcons.Favorite),
     SLEEP("sleep", "Sleep", AppIcons.Bedtime),
+    /** Overnight HRV from sleep payload; 0 samples if the band does not support HRV. */
+    HRV("hrv", "HRV (overnight)", AppIcons.MonitorHeart),
     STEPS("steps", "Steps", AppIcons.DirectionsWalk),
     DISTANCE("distance", "Distance", AppIcons.Straighten),
     ACTIVE_CALORIES("active_calories", "Active Calories", AppIcons.LocalFireDepartment),

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/sync/SyncViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/sync/SyncViewModel.kt
@@ -97,6 +97,7 @@ class SyncViewModel(
         "heart_rate" -> progress.heartRate
         "resting_heart_rate" -> progress.restingHeartRate
         "sleep" -> progress.sleep
+        "hrv" -> progress.hrv
         "steps" -> progress.steps
         "distance" -> progress.distance
         "active_calories" -> progress.activeCalories

--- a/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/data/parse/MiFitnessParsersTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/data/parse/MiFitnessParsersTest.kt
@@ -249,5 +249,92 @@ class MiFitnessParsersTest {
         assertEquals(1_700_036_000L, session.endTime)
         assertEquals(2, session.stages.size)
         assertTrue(session.stages.all { it.stage in 2..3 })
+        assertEquals(null, session.avgHrvMs)
+    }
+
+    @Test
+    fun parseSleepSession_withHrv_populatesOvernightFields() {
+        val entry = RawFitnessEntry(
+            key = "sleep",
+            time = 1_700_003_600L,
+            value = """
+                {
+                  "bedtime": 1700000000,
+                  "wake_up_time": 1700036000,
+                  "avg_hrv": 42,
+                  "min_hrv": 28,
+                  "max_hrv": 65,
+                  "hrv_analysis_timestamp": 1700035000,
+                  "items": [
+                    {"start_time": 1700000000, "end_time": 1700036000, "state": 2}
+                  ]
+                }
+            """.trimIndent(),
+        )
+        val session = MiFitnessParsers.parseSleepSession(entry)
+        assertNotNull(session)
+        assertEquals(42, session.avgHrvMs)
+        assertEquals(28, session.minHrvMs)
+        assertEquals(65, session.maxHrvMs)
+        assertEquals(1_700_035_000L, session.hrvAnalysisTimeSec)
+
+        val hrv = MiFitnessParsers.hrvSamplesFromSessions(listOf(session))
+        assertEquals(1, hrv.size)
+        assertEquals(1_700_035_000L, hrv[0].timestamp)
+        assertEquals(42.0, hrv[0].hrvMs)
+    }
+
+    @Test
+    fun parseHrvSamples_withoutAvgHrv_isEmpty() {
+        val entry = RawFitnessEntry(
+            key = "sleep",
+            time = 1_700_003_600L,
+            value = """
+                {
+                  "bedtime": 1700000000,
+                  "wake_up_time": 1700036000,
+                  "items": []
+                }
+            """.trimIndent(),
+        )
+        val samples = MiFitnessParsers.parseHrvSamples(listOf(entry))
+        assertTrue(samples.isEmpty())
+    }
+
+    @Test
+    fun parseHrvSamples_fallsBackToWakeTimeWhenAnalysisMissing() {
+        val entry = RawFitnessEntry(
+            key = "sleep",
+            time = 1_700_003_600L,
+            value = """
+                {
+                  "bedtime": 1700000000,
+                  "wake_up_time": 1700036000,
+                  "avg_hrv": 55,
+                  "items": []
+                }
+            """.trimIndent(),
+        )
+        val samples = MiFitnessParsers.parseHrvSamples(listOf(entry))
+        assertEquals(1, samples.size)
+        assertEquals(1_700_036_000L, samples[0].timestamp)
+        assertEquals(55.0, samples[0].hrvMs)
+    }
+
+    @Test
+    fun parseHrvSamples_rejectsImplausibleValues() {
+        val entry = RawFitnessEntry(
+            key = "sleep",
+            time = 1_700_003_600L,
+            value = """
+                {
+                  "bedtime": 1700000000,
+                  "wake_up_time": 1700036000,
+                  "avg_hrv": 999,
+                  "items": []
+                }
+            """.trimIndent(),
+        )
+        assertTrue(MiFitnessParsers.parseHrvSamples(listOf(entry)).isEmpty())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthDataNormalizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthDataNormalizerTest.kt
@@ -98,11 +98,27 @@ class HealthDataNormalizerTest {
                 SleepStage(1_700_000_000L, 1_700_001_800L, 2),
                 SleepStage(1_700_001_800L, 1_700_003_600L, 3),
             ),
+            avgHrvMs = 40,
         )
         val bad = SleepSession(startTime = 100L, endTime = 50L)
         val out = HealthDataNormalizer.normalizeSleep(listOf(good, bad))
         assertEquals(1, out.size)
         assertEquals(2, out[0].stages.size)
+        assertEquals(40, out[0].avgHrvMs)
+    }
+
+    @Test
+    fun normalizeHrv_filtersAndDedupes() {
+        val out = HealthDataNormalizer.normalizeHrv(
+            listOf(
+                com.bettermifitness.sync.data.api.HrvSample(1_700_003_600L, 42.0),
+                com.bettermifitness.sync.data.api.HrvSample(1_700_003_600L, 48.0), // same second, last wins
+                com.bettermifitness.sync.data.api.HrvSample(1_700_003_600L, 0.0), // invalid
+                com.bettermifitness.sync.data.api.HrvSample(100L, 30.0), // implausible time
+            ),
+        )
+        assertEquals(1, out.size)
+        assertEquals(48.0, out[0].hrvMs)
     }
 
     @Test
@@ -113,7 +129,6 @@ class HealthDataNormalizerTest {
         assertEquals("awake", HealthDataNormalizer.miSleepStageLabel(5))
         assertTrue(HealthDataNormalizer.miSleepStageLabel(99) == "unknown")
     }
-}
 
     @Test
     fun normalizeRoute_filtersAndDedupes() {
@@ -132,3 +147,4 @@ class HealthDataNormalizerTest {
         assertEquals(start + 10, out[0].timeSec)
         assertEquals(start + 40, out[1].timeSec)
     }
+}

--- a/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
@@ -4,6 +4,7 @@ import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
 import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.HrvSample
 import com.bettermifitness.sync.data.api.SleepSession
 import com.bettermifitness.sync.data.api.SpO2Sample
 import com.bettermifitness.sync.data.api.StepsRecord
@@ -30,6 +31,7 @@ import platform.HealthKit.HKQuantityTypeIdentifierBodyMass
 import platform.HealthKit.HKQuantityTypeIdentifierBodyTemperature
 import platform.HealthKit.HKQuantityTypeIdentifierDistanceWalkingRunning
 import platform.HealthKit.HKQuantityTypeIdentifierHeartRate
+import platform.HealthKit.HKQuantityTypeIdentifierHeartRateVariabilitySDNN
 import platform.HealthKit.HKQuantityTypeIdentifierOxygenSaturation
 import platform.HealthKit.HKQuantityTypeIdentifierRestingHeartRate
 import platform.HealthKit.HKQuantityTypeIdentifierStepCount
@@ -411,6 +413,33 @@ actual class HealthWriter : HealthStore {
                 metadata = mapOf<Any?, Any?>(
                     HKMetadataKeySyncIdentifier to HealthRecordIds.vo2Max(s.timestamp),
                     HKMetadataKeySyncVersion to HealthRecordIds.version(s.timestamp, s.mlPerKgMin),
+                ),
+            )
+        }
+        saveSamples(hkSamples)
+    }
+
+    /**
+     * Writes Mi overnight HRV (ms) into HealthKit HRV SDNN type.
+     * Apple only exposes SDNN publicly; Mi's wrist overnight value is closest available mapping.
+     */
+    actual override suspend fun writeHrv(samples: List<HrvSample>) {
+        val clean = HealthDataNormalizer.normalizeHrv(samples)
+        if (clean.isEmpty()) return
+        val type = HKQuantityType.quantityTypeForIdentifier(
+            HKQuantityTypeIdentifierHeartRateVariabilitySDNN,
+        ) ?: return
+        val unit = HKUnit.unitFromString("ms")
+        val hkSamples = clean.map { s ->
+            val date = NSDate.dateWithTimeIntervalSince1970(s.timestamp.toDouble())
+            HKQuantitySample.quantitySampleWithType(
+                quantityType = type,
+                quantity = HKQuantity.quantityWithUnit(unit, s.hrvMs),
+                startDate = date,
+                endDate = date,
+                metadata = mapOf<Any?, Any?>(
+                    HKMetadataKeySyncIdentifier to HealthRecordIds.hrv(s.timestamp),
+                    HKMetadataKeySyncVersion to HealthRecordIds.version(s.timestamp, s.hrvMs),
                 ),
             )
         }

--- a/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/IosHealthKitShareTypes.kt
+++ b/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/IosHealthKitShareTypes.kt
@@ -20,6 +20,7 @@ import platform.HealthKit.HKQuantityTypeIdentifierDistanceWalkingRunning
 import platform.HealthKit.HKQuantityTypeIdentifierFlightsClimbed
 import platform.HealthKit.HKQuantityTypeIdentifierHeartRate
 import platform.HealthKit.HKQuantityTypeIdentifierHeartRateRecoveryOneMinute
+import platform.HealthKit.HKQuantityTypeIdentifierHeartRateVariabilitySDNN
 import platform.HealthKit.HKQuantityTypeIdentifierOxygenSaturation
 import platform.HealthKit.HKQuantityTypeIdentifierRestingHeartRate
 import platform.HealthKit.HKQuantityTypeIdentifierRunningGroundContactTime
@@ -55,6 +56,7 @@ object IosHealthKitShareTypes {
         HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBloodPressureSystolic),
         HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBloodPressureDiastolic),
         HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierVO2Max),
+        HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeartRateVariabilitySDNN),
         HKCategoryType.categoryTypeForIdentifier(HKCategoryTypeIdentifierSleepAnalysis),
         HKObjectType.workoutType(),
         HKSeriesType.workoutRouteType(),


### PR DESCRIPTION
Adds support for syncing overnight HRV from Mi sleep payloads.

Closes #1