### PR TITLE
fix: renew Mi session via passToken like official app

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/MiSessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/MiSessionManager.kt
@@ -7,10 +7,12 @@ import com.mifitness.miclient.api.MiDataClient
 import com.mifitness.miclient.auth.MiAuth
 import com.mifitness.miclient.auth.MiAuthException
 import com.mifitness.miclient.auth.MiCredentials
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Holds the current Mi session (authenticated API client).
- * Can re-mint serviceToken via [refreshSession] using the stored passToken.
+ * Can re-mint serviceToken via [refreshSession] using the stored passToken (APK force-refresh).
  */
 class MiSessionManager(
     private val credentialsStore: CredentialsPort,
@@ -18,6 +20,7 @@ class MiSessionManager(
 ) : SyncSessionPort {
     private var dataClient: MiDataClient? = null
     private var directApi: MiDirectApi? = null
+    private val refreshMutex = Mutex()
 
     /** The active API client. Throws if not logged in. */
     val api: MiDirectApi
@@ -46,6 +49,9 @@ class MiSessionManager(
     override suspend fun ensureActive(): Boolean {
         if (isActive) return true
         val creds = credentialsStore.loadCredentials() ?: return false
+        if (creds.serviceToken.isBlank() || creds.userId.isBlank() || creds.ssecurity.isBlank()) {
+            return false
+        }
         activate(creds)
         return true
     }
@@ -62,23 +68,52 @@ class MiSessionManager(
 
     /**
      * Uses passToken to obtain a new serviceToken, persists it, and re-activates the client.
-     * Region mode is applied in [CredentialsStore.saveCredentials] so manual override is kept.
-     * @return true if refresh succeeded
+     * Serialized so concurrent metric failures do not stampede passport (APK update lock).
      */
-    suspend fun refreshSession(): Boolean {
-        val current = credentialsStore.loadCredentials() ?: return false
-        if (current.passToken.isBlank()) return false
-        return try {
+    suspend fun refreshSessionDetailed(): SessionRefreshResult = refreshMutex.withLock {
+        val current = credentialsStore.loadCredentials()
+            ?: return@withLock SessionRefreshResult.NeedsReLogin("No saved credentials")
+        if (current.passToken.isBlank()) {
+            return@withLock SessionRefreshResult.NeedsReLogin(
+                "No passToken saved — sign in again to stay connected across days",
+            )
+        }
+        if (current.deviceId.isBlank()) {
+            return@withLock SessionRefreshResult.NeedsReLogin(
+                "No deviceId saved — sign in again",
+            )
+        }
+
+        return@withLock try {
             val refreshed = miAuth.refreshWithPassToken(current)
             credentialsStore.saveCredentials(refreshed)
-            // loadCredentials re-applies auto/manual effective region
             val effective = credentialsStore.loadCredentials() ?: refreshed
             activate(effective)
-            true
-        } catch (_: MiAuthException) {
-            false
-        } catch (_: Exception) {
-            false
+            SessionRefreshResult.Success
+        } catch (e: MiAuthException) {
+            when (e.kind) {
+                MiAuthException.Kind.MissingPassToken,
+                MiAuthException.Kind.MissingDeviceId,
+                MiAuthException.Kind.InvalidCredential,
+                -> SessionRefreshResult.NeedsReLogin(e.message ?: "Sign in again")
+                MiAuthException.Kind.NeedsVerification ->
+                    SessionRefreshResult.NeedsVerification(
+                        reason = e.message ?: "Xiaomi requires re-verification",
+                        notificationUrl = e.notificationUrl,
+                    )
+                MiAuthException.Kind.StsFailed,
+                MiAuthException.Kind.Generic,
+                -> SessionRefreshResult.TransientFailure(e.message ?: "Session refresh failed")
+            }
+        } catch (e: Exception) {
+            SessionRefreshResult.TransientFailure(
+                e.message?.takeIf { it.isNotBlank() } ?: (e::class.simpleName ?: "Refresh error"),
+            )
         }
     }
+
+    /**
+     * @return true if refresh succeeded
+     */
+    suspend fun refreshSession(): Boolean = refreshSessionDetailed().isSuccess
 }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/SessionRefreshResult.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/SessionRefreshResult.kt
@@ -1,0 +1,32 @@
+package com.bettermifitness.sync.data
+
+/**
+ * Outcome of passToken → serviceToken refresh (APK force-refresh parity).
+ */
+sealed class SessionRefreshResult {
+    data object Success : SessionRefreshResult()
+
+    /** passToken invalid/missing — full sign-in required. */
+    data class NeedsReLogin(val reason: String) : SessionRefreshResult()
+
+    /** Xiaomi security challenge during refresh. */
+    data class NeedsVerification(
+        val reason: String,
+        val notificationUrl: String? = null,
+    ) : SessionRefreshResult()
+
+    /** Network / STS glitch — may retry later. */
+    data class TransientFailure(val reason: String) : SessionRefreshResult()
+
+    val isSuccess: Boolean get() = this is Success
+
+    val userMessage: String
+        get() = when (this) {
+            Success -> "Session renewed"
+            is NeedsReLogin -> reason.ifBlank { "Session expired — sign in again" }
+            is NeedsVerification -> reason.ifBlank {
+                "Xiaomi requires re-verification — sign in again"
+            }
+            is TransientFailure -> reason.ifBlank { "Could not renew session — try again" }
+        }
+}

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/CredentialsStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/CredentialsStore.kt
@@ -40,6 +40,11 @@ class CredentialsStore(
             preferences[SSECURITY_KEY] = credentials.ssecurity
             preferences[PASS_TOKEN_KEY] = credentials.passToken
             preferences[DEVICE_ID_KEY] = credentials.deviceId
+            if (credentials.cUserId.isNotBlank()) {
+                preferences[C_USER_ID_KEY] = credentials.cUserId
+            } else {
+                preferences.remove(C_USER_ID_KEY)
+            }
 
             val loginFromSts = MiRegion.normalizeCode(credentials.region)
             preferences[LOGIN_REGION_KEY] = loginFromSts
@@ -58,8 +63,10 @@ class CredentialsStore(
         val serviceToken = prefs[TOKEN_KEY] ?: return null
         val userId = prefs[MI_USER_ID_KEY] ?: return null
         val ssecurity = prefs[SSECURITY_KEY] ?: return null
-        val passToken = prefs[PASS_TOKEN_KEY] ?: return null
-        val deviceId = prefs[DEVICE_ID_KEY] ?: return null
+        // passToken may be blank on legacy installs; still load for in-memory API until re-login.
+        val passToken = prefs[PASS_TOKEN_KEY] ?: ""
+        val deviceId = prefs[DEVICE_ID_KEY] ?: ""
+        val cUserId = prefs[C_USER_ID_KEY] ?: ""
         val effective = MiRegion.normalizeCode(
             prefs[REGION_KEY] ?: prefs[LOGIN_REGION_KEY],
         )
@@ -70,6 +77,7 @@ class CredentialsStore(
             passToken = passToken,
             deviceId = deviceId,
             region = effective,
+            cUserId = cUserId,
         )
     }
 
@@ -102,6 +110,7 @@ class CredentialsStore(
             preferences.remove(SSECURITY_KEY)
             preferences.remove(PASS_TOKEN_KEY)
             preferences.remove(DEVICE_ID_KEY)
+            preferences.remove(C_USER_ID_KEY)
         }
     }
 
@@ -116,5 +125,6 @@ class CredentialsStore(
         private val SSECURITY_KEY = stringPreferencesKey("ssecurity")
         private val PASS_TOKEN_KEY = stringPreferencesKey("pass_token")
         private val DEVICE_ID_KEY = stringPreferencesKey("device_id")
+        private val C_USER_ID_KEY = stringPreferencesKey("c_user_id")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
@@ -1,6 +1,7 @@
 package com.bettermifitness.sync.data.repository
 
 import com.bettermifitness.sync.data.MiSessionManager
+import com.bettermifitness.sync.data.SessionRefreshResult
 import com.bettermifitness.sync.data.api.HeartRateEntry
 import com.bettermifitness.sync.data.api.WorkoutSession
 import com.bettermifitness.sync.data.parse.MiFitnessParsers
@@ -49,6 +50,8 @@ class HealthRepository(
 
     private var authRefreshTried = false
     private var sawAuthFailure = false
+    private var lastRefreshUserMessage: String? = null
+    private var lastRefreshRetryable: Boolean = false
     private val retryableFailures = mutableListOf<Boolean>()
 
     override suspend fun syncAll(
@@ -58,6 +61,8 @@ class HealthRepository(
     ): SyncRunResult {
         authRefreshTried = false
         sawAuthFailure = false
+        lastRefreshUserMessage = null
+        lastRefreshRetryable = false
         retryableFailures.clear()
         _syncProgress.value = SyncProgress()
 
@@ -297,8 +302,22 @@ class HealthRepository(
             sawAuthFailure = true
             if (!authRefreshTried) {
                 authRefreshTried = true
-                if (session.refreshSession()) {
-                    return block()
+                when (val refresh = session.refreshSessionDetailed()) {
+                    SessionRefreshResult.Success -> {
+                        lastRefreshUserMessage = null
+                        lastRefreshRetryable = false
+                        return block()
+                    }
+                    is SessionRefreshResult.TransientFailure -> {
+                        lastRefreshUserMessage = refresh.userMessage
+                        lastRefreshRetryable = true
+                    }
+                    is SessionRefreshResult.NeedsReLogin,
+                    is SessionRefreshResult.NeedsVerification,
+                    -> {
+                        lastRefreshUserMessage = refresh.userMessage
+                        lastRefreshRetryable = false
+                    }
                 }
             }
             throw e
@@ -309,7 +328,7 @@ class HealthRepository(
         when (e) {
             is MiApiException.AuthExpired -> {
                 sawAuthFailure = true
-                retryableFailures += false
+                retryableFailures += lastRefreshRetryable
             }
             is MiApiException -> retryableFailures += e.isRetryable
             else -> retryableFailures += true
@@ -319,7 +338,9 @@ class HealthRepository(
     private fun friendlyMessage(e: Exception): String {
         return when (e) {
             is MiApiException.AuthExpired ->
-                e.message?.takeIf { it.isNotBlank() } ?: "Session expired — sign in again"
+                lastRefreshUserMessage
+                    ?: e.message?.takeIf { it.isNotBlank() }
+                    ?: "Session expired — sign in again"
             is MiApiException.Network ->
                 e.message?.takeIf { it.isNotBlank() } ?: "Network error"
             is MiApiException.RateLimited ->

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.bettermifitness.sync.health.HealthReadiness
 import com.bettermifitness.sync.sync.SyncOutcomeLabels
 import com.bettermifitness.sync.ui.SyncMetric
 import com.bettermifitness.sync.util.RelativeTime
+import com.mifitness.miclient.api.MiApiException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -157,6 +158,19 @@ class HomeViewModel(
             try {
                 _profile.value = session.api.getMe()
                 _profileError.value = null
+            } catch (e: MiApiException.AuthExpired) {
+                val refresh = session.refreshSessionDetailed()
+                if (refresh.isSuccess) {
+                    try {
+                        _profile.value = session.api.getMe()
+                        _profileError.value = null
+                        return@launch
+                    } catch (retry: Exception) {
+                        _profileError.value = retry.message ?: "Failed to load profile"
+                        return@launch
+                    }
+                }
+                _profileError.value = refresh.userMessage
             } catch (e: Exception) {
                 _profileError.value = e.message ?: "Failed to load profile"
             }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/login/LoginViewModel.kt
@@ -208,6 +208,25 @@ class LoginViewModel(
     }
 
     private suspend fun persistAndSucceed(credentials: MiCredentials) {
+        if (credentials.passToken.isBlank()) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    errorMessage = "Login did not return a passToken, so the app cannot stay " +
+                        "signed in across days. Try again or use the other login method.",
+                )
+            }
+            return
+        }
+        if (credentials.deviceId.isBlank()) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    errorMessage = "Login missing device id — try again.",
+                )
+            }
+            return
+        }
         sessionManager.activate(credentials)
         credentialsStore.saveCredentials(credentials)
         // Pick the health cloud shard that actually holds the newest samples.

--- a/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/data/SessionRefreshResultTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/data/SessionRefreshResultTest.kt
@@ -1,0 +1,27 @@
+package com.bettermifitness.sync.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SessionRefreshResultTest {
+    @Test
+    fun successFlags() {
+        assertTrue(SessionRefreshResult.Success.isSuccess)
+        assertFalse(SessionRefreshResult.NeedsReLogin("x").isSuccess)
+        assertFalse(SessionRefreshResult.TransientFailure("y").isSuccess)
+    }
+
+    @Test
+    fun userMessagesPreferReason() {
+        assertEquals(
+            "please re-auth",
+            SessionRefreshResult.NeedsReLogin("please re-auth").userMessage,
+        )
+        assertEquals(
+            "verify",
+            SessionRefreshResult.NeedsVerification("verify", notificationUrl = "https://x").userMessage,
+        )
+    }
+}

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/api/MiDataClient.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/api/MiDataClient.kt
@@ -169,9 +169,15 @@ class MiDataClient(
     }
 
     private fun buildCookieHeader(): String {
+        // APK plantHealthCookie uses cUserId for .hlth.io.mi.com; fall back to userId for legacy sessions.
+        val identityCookie = if (credentials.cUserId.isNotBlank()) {
+            "cUserId=${credentials.cUserId}"
+        } else {
+            "userId=${credentials.userId}"
+        }
         return listOf(
             "serviceToken=${credentials.serviceToken}",
-            "userId=${credentials.userId}",
+            identityCookie,
             "locale=en",
             "auth_key=$AUTH_KEY",
         ).joinToString("; ")

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/LoginResult.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/LoginResult.kt
@@ -217,4 +217,24 @@ interface MiAuthHost {
     ): Pair<String, String>
 }
 
-class MiAuthException(message: String) : Exception(message)
+/**
+ * Passport / STS failures.
+ * [kind] lets the app decide re-login vs verification vs retry without parsing messages.
+ */
+class MiAuthException(
+    message: String,
+    val kind: Kind = Kind.Generic,
+    val notificationUrl: String? = null,
+    val businessCode: Int? = null,
+) : Exception(message) {
+    enum class Kind {
+        Generic,
+        /** passToken rejected / missing — full sign-in required. */
+        InvalidCredential,
+        /** Xiaomi securityStatus / notification challenge. */
+        NeedsVerification,
+        MissingDeviceId,
+        MissingPassToken,
+        StsFailed,
+    }
+}

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/MiAuth.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/MiAuth.kt
@@ -16,11 +16,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 
 /**
  * Mi Account authentication façade (password, OTP handoff, STS browser callback).
  *
- * Internals are split across [PassportAuthUtils], [PassportHttpSession], and [LoginResult.OtpRequired].
+ * Session refresh follows the official passport path:
+ * passToken cookies → `/pass/serviceLogin` → signed STS (`clientSign`) → new serviceToken.
  */
 class MiAuth(
     private val userAgent: String = PassportAuthUtils.DEFAULT_USER_AGENT,
@@ -71,7 +73,10 @@ class MiAuth(
         val params = parseQueryString(parsedUrl.encodedQuery)
         val deviceId = params["d"]
             ?: params["deviceId"]
-            ?: throw MiAuthException("Missing device id (d=…) in redirect URL — copy the full address bar URL")
+            ?: throw MiAuthException(
+                "Missing device id (d=…) in redirect URL — copy the full address bar URL",
+                kind = MiAuthException.Kind.MissingDeviceId,
+            )
         val regionFromUrl = params["p_ur"] ?: ""
 
         val cookieStorage = AcceptAllCookiesStorage()
@@ -79,7 +84,6 @@ class MiAuth(
         PassportHttpSession.seedDeviceIdCookie(cookieStorage, deviceId)
 
         try {
-            // One-shot GET is not enough — STS often 302s while setting serviceToken.
             val (serviceToken, regionFromRedirects) = followRedirectsCollectingServiceToken(
                 client,
                 cleaned,
@@ -89,6 +93,7 @@ class MiAuth(
                     "Could not get a session from that redirect URL. " +
                         "Open the login page again, finish sign-in, then paste the new full URL " +
                         "(it should start with https://sts-hlth.io.mi.com/).",
+                    kind = MiAuthException.Kind.StsFailed,
                 )
             }
 
@@ -101,15 +106,24 @@ class MiAuth(
 
             val userId = cookie("userId")
             val passToken = cookie("passToken")
-            val ssecurity = if (userId.isNotEmpty() && passToken.isNotEmpty()) {
+            val cUserId = cookie("cUserId")
+            if (passToken.isBlank()) {
+                throw MiAuthException(
+                    "Browser login did not yield a passToken, so the session cannot be refreshed later. " +
+                        "Try password login or paste the URL immediately after Xiaomi shows “ok”.",
+                    kind = MiAuthException.Kind.MissingPassToken,
+                )
+            }
+            val ssecurity = if (userId.isNotEmpty()) {
                 harvestSsecurity(client, userId, passToken, deviceId, sid)
             } else {
                 ""
             }
-            if (ssecurity.isEmpty()) {
+            if (ssecurity.isEmpty() || userId.isEmpty()) {
                 throw MiAuthException(
                     "Got a service token but not full session details. " +
                         "Try browser login again and paste the URL as soon as the page says “ok”.",
+                    kind = MiAuthException.Kind.StsFailed,
                 )
             }
 
@@ -122,6 +136,7 @@ class MiAuth(
                 region = PassportAuthUtils.resolveRegion(
                     regionFromUrl.ifBlank { regionFromRedirects },
                 ),
+                cUserId = cUserId,
             )
         } finally {
             client.close()
@@ -137,7 +152,7 @@ class MiAuth(
 
     /**
      * Re-mint serviceToken (and ssecurity when needed) using a stored [passToken].
-     * Used when Mi health APIs reject an expired session without forcing a full password login.
+     * Mirrors APK force-refresh via [XMPassport.loginByPassToken] + signed STS.
      */
     suspend fun refreshWithPassToken(
         credentials: MiCredentials,
@@ -145,13 +160,25 @@ class MiAuth(
         callback: String = PassportAuthUtils.DEFAULT_STS_CALLBACK,
     ): MiCredentials {
         if (credentials.passToken.isBlank()) {
-            throw MiAuthException("No passToken saved — sign in again")
+            throw MiAuthException(
+                "No passToken saved — sign in again",
+                kind = MiAuthException.Kind.MissingPassToken,
+            )
         }
         if (credentials.userId.isBlank()) {
-            throw MiAuthException("No userId saved — sign in again")
+            throw MiAuthException(
+                "No userId saved — sign in again",
+                kind = MiAuthException.Kind.InvalidCredential,
+            )
+        }
+        if (credentials.deviceId.isBlank()) {
+            throw MiAuthException(
+                "No deviceId saved — sign in again (device identity is required for refresh)",
+                kind = MiAuthException.Kind.MissingDeviceId,
+            )
         }
 
-        val deviceId = credentials.deviceId.ifBlank { PassportAuthUtils.generateDeviceId() }
+        val deviceId = credentials.deviceId
         val cookieStorage = AcceptAllCookiesStorage()
         val client = PassportHttpSession.buildClient(cookieStorage)
         PassportHttpSession.seedDeviceIdCookie(cookieStorage, deviceId)
@@ -165,22 +192,22 @@ class MiAuth(
         )
 
         return try {
-            val refreshed = tryLoginWithPassTokenCookies(
+            val refreshed = loginWithPassTokenCookies(
                 client = client,
                 cookieStorage = cookieStorage,
                 deviceId = deviceId,
                 sid = sid,
                 callback = callback,
-            ) ?: throw MiAuthException("Session refresh failed — sign in again")
+                previousPassToken = credentials.passToken,
+                previousCUserId = credentials.cUserId,
+            )
 
-            // STS may omit region; keep the previously stored health region when blank.
             val region = refreshed.region.takeIf { it.isNotBlank() }
                 ?: credentials.region.takeIf { it.isNotBlank() }
                 ?: "sg"
             refreshed.copy(
                 deviceId = deviceId,
                 region = region,
-                passToken = refreshed.passToken.ifBlank { credentials.passToken },
             )
         } finally {
             client.close()
@@ -205,7 +232,11 @@ class MiAuth(
             val desc = authResponse["desc"]?.jsonPrimitive?.content
                 ?: authResponse["description"]?.jsonPrimitive?.content
                 ?: "Login failed"
-            throw MiAuthException(PassportAuthUtils.friendlyLoginError(code, desc))
+            throw MiAuthException(
+                PassportAuthUtils.friendlyLoginError(code, desc),
+                kind = MiAuthException.Kind.InvalidCredential,
+                businessCode = code,
+            )
         }
 
         val securityStatus = authResponse["securityStatus"]?.jsonPrimitive?.int ?: 0
@@ -262,32 +293,51 @@ class MiAuth(
             }
         }
 
-        val passTokenCreds = tryLoginWithPassTokenCookies(
-            client, cookieStorage, deviceId, sid, callback,
-        )
-        if (passTokenCreds != null) {
+        return try {
+            val passTokenCreds = loginWithPassTokenCookies(
+                client = client,
+                cookieStorage = cookieStorage,
+                deviceId = deviceId,
+                sid = sid,
+                callback = callback,
+                previousPassToken = null,
+                previousCUserId = "",
+            )
             client.close()
-            return passTokenCreds
+            passTokenCreds
+        } catch (e: MiAuthException) {
+            client.close()
+            throw MiAuthException(
+                "OTP_ACCEPTED_NEEDS_BROWSER: Email code was accepted, but Xiaomi still " +
+                    "won't finish app login for this session. Use browser login once to trust this device. " +
+                    "(${e.message})",
+                kind = MiAuthException.Kind.NeedsVerification,
+            )
         }
-
-        client.close()
-        throw MiAuthException(
-            "OTP_ACCEPTED_NEEDS_BROWSER: Email code was accepted, but Xiaomi still " +
-                "won't finish app login for this session. Use browser login once to trust this device.",
-        )
     }
 
-    private suspend fun tryLoginWithPassTokenCookies(
+    /**
+     * passToken cookie login + STS — APK [XMPassport.loginByPassToken] shape.
+     * Throws [MiAuthException] with typed [MiAuthException.kind] instead of silent null.
+     */
+    private suspend fun loginWithPassTokenCookies(
         client: HttpClient,
         cookieStorage: AcceptAllCookiesStorage,
         deviceId: String,
         sid: String,
         callback: String,
-    ): MiCredentials? {
+        previousPassToken: String?,
+        previousCUserId: String,
+    ): MiCredentials {
         val accountCookies = cookieStorage.get(Url("https://account.xiaomi.com/"))
         val userId = accountCookies.firstOrNull { it.name == "userId" }?.value?.takeIf { it.isNotBlank() }
         val passToken = accountCookies.firstOrNull { it.name == "passToken" }?.value?.takeIf { it.isNotBlank() }
-        if (userId.isNullOrEmpty() || passToken.isNullOrEmpty()) return null
+        if (userId.isNullOrEmpty() || passToken.isNullOrEmpty()) {
+            throw MiAuthException(
+                "Missing userId/passToken cookies for session refresh",
+                kind = MiAuthException.Kind.MissingPassToken,
+            )
+        }
 
         PassportHttpSession.seedDeviceIdCookie(cookieStorage, deviceId)
         cookieStorage.addCookie(
@@ -308,25 +358,73 @@ class MiAuth(
         val obj = try {
             json.parseToJsonElement(body).jsonObject
         } catch (_: Exception) {
-            return null
+            throw MiAuthException(
+                "Session refresh returned non-JSON from serviceLogin",
+                kind = MiAuthException.Kind.StsFailed,
+            )
         }
         val code = obj["code"]?.jsonPrimitive?.int ?: -1
-        if (code != 0) return null
+        if (code != 0) {
+            val desc = obj["desc"]?.jsonPrimitive?.content
+                ?: obj["description"]?.jsonPrimitive?.content
+                ?: "passToken login failed"
+            throw MiAuthException(
+                PassportAuthUtils.friendlyLoginError(code, desc),
+                kind = MiAuthException.Kind.InvalidCredential,
+                businessCode = code,
+            )
+        }
         val securityStatus = obj["securityStatus"]?.jsonPrimitive?.int ?: 0
-        if (securityStatus != 0) return null
+        if (securityStatus != 0) {
+            val notification = obj["notificationUrl"]?.jsonPrimitive?.content
+            throw MiAuthException(
+                "Xiaomi requires re-verification to renew the session (securityStatus=$securityStatus)",
+                kind = MiAuthException.Kind.NeedsVerification,
+                notificationUrl = notification?.let { PassportAuthUtils.absUrl(it) },
+                businessCode = securityStatus,
+            )
+        }
 
         val ssecurity = obj["ssecurity"]?.jsonPrimitive?.content
             ?: harvestSsecurity(client, userId, passToken, deviceId, sid)
+        if (ssecurity.isEmpty()) {
+            throw MiAuthException(
+                "Session refresh missing ssecurity",
+                kind = MiAuthException.Kind.StsFailed,
+            )
+        }
+
         val location = obj["location"]?.jsonPrimitive?.content
-        val passFromBody = obj["passToken"]?.jsonPrimitive?.content ?: passToken
+        val nonce = obj["nonce"]?.let { el ->
+            try {
+                el.jsonPrimitive.long.toString()
+            } catch (_: Exception) {
+                el.jsonPrimitive.content
+            }
+        }.orEmpty()
+
+        val rePassHeader = response.headers["re-pass-token"]
+            ?: response.headers["Re-Pass-Token"]
+        val passFromBody = obj["passToken"]?.jsonPrimitive?.content
+        val effectivePass = PassportSts.preferRotatedPassToken(
+            oldPassToken = previousPassToken ?: passToken,
+            newPassToken = passFromBody ?: passToken,
+            rePassTokenHeader = rePassHeader,
+        )
         val uid = PassportAuthUtils.jsonUserId(obj).ifEmpty { userId }
+        val cUserId = obj["cUserId"]?.jsonPrimitive?.content
+            ?: obj["encryptedUserId"]?.jsonPrimitive?.content
+            ?: previousCUserId
 
         val serviceToken: String
         val region: String
         if (!location.isNullOrEmpty()) {
-            val pair = followRedirectsCollectingServiceToken(
-                client,
-                PassportAuthUtils.absUrl(location),
+            val pair = exchangeStsLocation(
+                client = client,
+                location = PassportAuthUtils.absUrl(location),
+                ssecurity = ssecurity,
+                nonce = nonce,
+                sid = sid,
             )
             serviceToken = pair.first
             region = pair.second
@@ -338,15 +436,21 @@ class MiAuth(
                 ?: ""
             region = ""
         }
-        if (serviceToken.isEmpty() || ssecurity.isEmpty()) return null
+        if (serviceToken.isEmpty()) {
+            throw MiAuthException(
+                "Session refresh did not yield a serviceToken",
+                kind = MiAuthException.Kind.StsFailed,
+            )
+        }
 
         return MiCredentials(
             userId = uid,
             ssecurity = ssecurity,
             serviceToken = serviceToken,
-            passToken = passFromBody,
+            passToken = effectivePass,
             deviceId = deviceId,
             region = PassportAuthUtils.resolveRegion(region),
+            cUserId = cUserId,
         )
     }
 
@@ -392,17 +496,42 @@ class MiAuth(
         deviceId: String,
     ): MiCredentials {
         val location = authResponse["location"]?.jsonPrimitive?.content
-            ?: throw MiAuthException("Login succeeded but no location URL (can't get serviceToken)")
+            ?: throw MiAuthException(
+                "Login succeeded but no location URL (can't get serviceToken)",
+                kind = MiAuthException.Kind.StsFailed,
+            )
         val userId = PassportAuthUtils.jsonUserId(authResponse)
         val ssecurity = authResponse["ssecurity"]?.jsonPrimitive?.content ?: ""
         val passToken = authResponse["passToken"]?.jsonPrimitive?.content ?: ""
+        if (passToken.isBlank()) {
+            throw MiAuthException(
+                "Login succeeded but no passToken — session cannot be refreshed later",
+                kind = MiAuthException.Kind.MissingPassToken,
+            )
+        }
+        val cUserId = authResponse["cUserId"]?.jsonPrimitive?.content
+            ?: authResponse["encryptedUserId"]?.jsonPrimitive?.content
+            ?: ""
+        val nonce = authResponse["nonce"]?.let { el ->
+            try {
+                el.jsonPrimitive.long.toString()
+            } catch (_: Exception) {
+                el.jsonPrimitive.content
+            }
+        }.orEmpty()
 
-        val (serviceToken, region) = followRedirectsCollectingServiceToken(
-            client,
-            PassportAuthUtils.absUrl(location),
+        val (serviceToken, region) = exchangeStsLocation(
+            client = client,
+            location = PassportAuthUtils.absUrl(location),
+            ssecurity = ssecurity,
+            nonce = nonce,
+            sid = PassportAuthUtils.DEFAULT_SID,
         )
         if (serviceToken.isEmpty()) {
-            throw MiAuthException("STS did not set serviceToken — location follow failed")
+            throw MiAuthException(
+                "STS did not set serviceToken — location follow failed",
+                kind = MiAuthException.Kind.StsFailed,
+            )
         }
 
         return MiCredentials(
@@ -412,12 +541,37 @@ class MiAuth(
             passToken = passToken,
             deviceId = deviceId,
             region = PassportAuthUtils.resolveRegion(region),
+            cUserId = cUserId,
         )
+    }
+
+    /**
+     * Prefer APK signed STS (`clientSign` + `_userIdNeedEncrypt`); fall back to bare redirect follow.
+     */
+    private suspend fun exchangeStsLocation(
+        client: HttpClient,
+        location: String,
+        ssecurity: String,
+        nonce: String,
+        sid: String,
+    ): Pair<String, String> {
+        if (ssecurity.isNotEmpty() && nonce.isNotEmpty()) {
+            val signed = PassportSts.signedLocationUrl(location, nonce, ssecurity)
+            val signedResult = followRedirectsCollectingServiceToken(client, signed, sid)
+            if (signedResult.first.isNotEmpty()) return signedResult
+        }
+        return followRedirectsCollectingServiceToken(client, location, sid)
     }
 
     override suspend fun followRedirectsCollectingServiceToken(
         client: HttpClient,
         startUrl: String,
+    ): Pair<String, String> = followRedirectsCollectingServiceToken(client, startUrl, PassportAuthUtils.DEFAULT_SID)
+
+    private suspend fun followRedirectsCollectingServiceToken(
+        client: HttpClient,
+        startUrl: String,
+        sid: String,
     ): Pair<String, String> {
         var serviceToken = ""
         var region = ""
@@ -429,10 +583,15 @@ class MiAuth(
             val cookieHeaders = (response.headers.getAll("Set-Cookie") ?: emptyList()) +
                 (response.headers.getAll("set-cookie") ?: emptyList())
             cookieHeaders.forEach { cookie ->
-                if (cookie.contains("serviceToken=")) {
-                    serviceToken = cookie.substringAfter("serviceToken=").substringBefore(";")
+                PassportSts.extractServiceTokenFromCookieHeader(cookie, sid)?.let {
+                    serviceToken = it
                 }
             }
+            // Some STS responses put tokens in plain headers (APK SimpleRequest headers map).
+            val headerToken = response.headers["serviceToken"]
+                ?: response.headers["${sid}_serviceToken"]
+            if (!headerToken.isNullOrBlank()) serviceToken = headerToken
+
             if (currentUrl.contains("p_ur=")) {
                 region = try {
                     parseQueryString(Url(currentUrl).encodedQuery)["p_ur"] ?: region

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/MiCredentials.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/MiCredentials.kt
@@ -1,8 +1,10 @@
 package com.mifitness.miclient.auth
 
 /**
- * The complete set of credentials needed to make encrypted Mi Fitness API calls.
- * Obtained from [MiAuth.completeLogin] after the user logs in via the WebView.
+ * Credentials needed for encrypted Mi Fitness API calls and session refresh.
+ *
+ * [passToken] is long-lived (passport); [serviceToken] + [ssecurity] are short-lived per SID.
+ * [cUserId] is Xiaomi's encrypted user id used in health cookies (APK `encryptedUserId`).
  */
 data class MiCredentials(
     val userId: String,
@@ -11,4 +13,5 @@ data class MiCredentials(
     val passToken: String,
     val deviceId: String,
     val region: String,
+    val cUserId: String = "",
 )

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/PassportSts.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/auth/PassportSts.kt
@@ -1,0 +1,69 @@
+package com.mifitness.miclient.auth
+
+import com.mifitness.miclient.crypto.Hash
+import io.ktor.http.encodeURLParameter
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * STS helpers matching Xiaomi passport SDK ([XMPassport.getClientSign] / getServiceTokenByStsUrl).
+ */
+@OptIn(ExperimentalEncodingApi::class)
+object PassportSts {
+    /**
+     * APK: `CloudCoder.generateSignature(null, null, {nonce=…}, ssecurity)`
+     * → Base64(SHA1("nonce=<nonce>&" + ssecurity)) with Android Base64.NO_WRAP.
+     */
+    fun clientSign(nonce: String, ssecurity: String): String {
+        require(nonce.isNotEmpty()) { "nonce required for clientSign" }
+        require(ssecurity.isNotEmpty()) { "ssecurity required for clientSign" }
+        val payload = "nonce=$nonce&$ssecurity"
+        return Base64.encode(Hash.sha1(payload.encodeToByteArray()))
+    }
+
+    /**
+     * Appends `clientSign` and `_userIdNeedEncrypt=true` to the STS location URL.
+     */
+    fun signedLocationUrl(location: String, nonce: String, ssecurity: String): String {
+        val abs = PassportAuthUtils.absUrl(location)
+        val sign = clientSign(nonce, ssecurity).encodeURLParameter()
+        val sep = if (abs.contains('?')) '&' else '?'
+        return "$abs${sep}clientSign=$sign&_userIdNeedEncrypt=true"
+    }
+
+    /** MD5 hex of [passToken] uppercase — used with `re-pass-token` response header. */
+    fun passTokenMd5Upper(passToken: String): String =
+        Hash.md5(passToken.encodeToByteArray())
+            .joinToString("") { it.toUByte().toString(16).padStart(2, '0') }
+            .uppercase()
+
+    /**
+     * Whether the server is rotating passToken (APK [AMPassTokenUpdateUtil] intent).
+     * Prefer body [newPassToken] when non-blank and different from old.
+     * If [rePassTokenHeader] is present, require it equals MD5(old).
+     */
+    fun preferRotatedPassToken(
+        oldPassToken: String,
+        newPassToken: String?,
+        rePassTokenHeader: String?,
+    ): String {
+        val candidate = newPassToken?.takeIf { it.isNotBlank() } ?: return oldPassToken
+        if (candidate == oldPassToken) return oldPassToken
+        val re = rePassTokenHeader?.trim().orEmpty()
+        if (re.isNotEmpty() && re.uppercase() != passTokenMd5Upper(oldPassToken)) {
+            return oldPassToken
+        }
+        return candidate
+    }
+
+    fun extractServiceTokenFromCookieHeader(cookie: String, sid: String = PassportAuthUtils.DEFAULT_SID): String? {
+        val prefixed = "${sid}_serviceToken="
+        return when {
+            cookie.contains(prefixed) ->
+                cookie.substringAfter(prefixed).substringBefore(";").takeIf { it.isNotBlank() }
+            cookie.contains("serviceToken=") ->
+                cookie.substringAfter("serviceToken=").substringBefore(";").takeIf { it.isNotBlank() }
+            else -> null
+        }
+    }
+}

--- a/miclient/src/commonTest/kotlin/com/mifitness/miclient/auth/PassportStsTest.kt
+++ b/miclient/src/commonTest/kotlin/com/mifitness/miclient/auth/PassportStsTest.kt
@@ -1,0 +1,88 @@
+package com.mifitness.miclient.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PassportStsTest {
+
+    @Test
+    fun clientSign_matchesApkSha1Base64NoWrap() {
+        // APK: Base64(SHA1("nonce=<n>&" + ssecurity), NO_WRAP)
+        val expected = "4V5zHfsiqQGpDuc8sofWmSUlPIo="
+        assertEquals(expected, PassportSts.clientSign("12345", "test-ssecurity-value"))
+    }
+
+    @Test
+    fun signedLocationUrl_appendsQueryWhenNoExistingParams() {
+        val url = PassportSts.signedLocationUrl(
+            location = "https://sts-hlth.io.mi.com/healthapp/sts",
+            nonce = "12345",
+            ssecurity = "test-ssecurity-value",
+        )
+        assertTrue(url.startsWith("https://sts-hlth.io.mi.com/healthapp/sts?"))
+        assertTrue(url.contains("clientSign="))
+        assertTrue(url.contains("_userIdNeedEncrypt=true"))
+        assertTrue(url.contains("clientSign=4V5zHfsiqQGpDuc8sofWmSUlPIo%3D") || url.contains("clientSign=4V5zHfsiqQGpDuc8sofWmSUlPIo="))
+    }
+
+    @Test
+    fun signedLocationUrl_appendsWithAmpersandWhenQueryExists() {
+        val url = PassportSts.signedLocationUrl(
+            location = "https://sts-hlth.io.mi.com/healthapp/sts?foo=1",
+            nonce = "12345",
+            ssecurity = "test-ssecurity-value",
+        )
+        assertTrue(url.contains("foo=1&clientSign="))
+        assertFalse(url.contains("?clientSign="))
+    }
+
+    @Test
+    fun passTokenMd5Upper_matchesApk() {
+        assertEquals(
+            "B6B00ADDF1314F2A49E8821A179584BA",
+            PassportSts.passTokenMd5Upper("oldPassToken"),
+        )
+    }
+
+    @Test
+    fun preferRotatedPassToken_acceptsNewWhenNoHeader() {
+        assertEquals(
+            "newToken",
+            PassportSts.preferRotatedPassToken("old", "newToken", rePassTokenHeader = null),
+        )
+    }
+
+    @Test
+    fun preferRotatedPassToken_acceptsWhenReHeaderMatchesMd5Old() {
+        val old = "oldPassToken"
+        val md5 = PassportSts.passTokenMd5Upper(old)
+        assertEquals(
+            "rotated",
+            PassportSts.preferRotatedPassToken(old, "rotated", rePassTokenHeader = md5),
+        )
+    }
+
+    @Test
+    fun preferRotatedPassToken_rejectsWhenReHeaderMismatches() {
+        assertEquals(
+            "old",
+            PassportSts.preferRotatedPassToken("old", "rotated", rePassTokenHeader = "DEADBEEF"),
+        )
+    }
+
+    @Test
+    fun extractServiceTokenFromCookieHeader_plainAndSidPrefixed() {
+        assertEquals(
+            "abc",
+            PassportSts.extractServiceTokenFromCookieHeader("serviceToken=abc; Path=/"),
+        )
+        assertEquals(
+            "xyz",
+            PassportSts.extractServiceTokenFromCookieHeader(
+                "miothealth_serviceToken=xyz; Domain=.mi.com",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Renew the Mi session using `passToken`, matching the official Mi app.

Closes #2