### PR TITLE
fix: Health Connect not-in-future times (issue #10)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
@@ -191,10 +191,12 @@ actual class HealthWriter(private val context: Context) : HealthStore {
     actual override suspend fun writeSteps(records: List<StepsRecord>) {
         val clean = HealthDataNormalizer.normalizeSteps(records)
         if (clean.isEmpty()) return
-        val hcRecords = clean.map { record ->
+        val hcRecords = clean.mapNotNull { record ->
             val ts = record.date.toLong()
             val start = Instant.ofEpochSecond(ts)
-            val end = start.plusSeconds(3599) // One hour bucket
+            // Clamp open hour end so HC never sees endTime in the future (issue #10 class).
+            val end = minOf(start.plusSeconds(3599), Instant.now())
+            if (!end.isAfter(start)) return@mapNotNull null
             val zo = ZoneOffsetResolver.fromMiOrSystem(record.tzIn15Min, start)
 
             HcStepsRecord(
@@ -210,7 +212,7 @@ actual class HealthWriter(private val context: Context) : HealthStore {
                 ),
             )
         }
-        client.insertRecords(hcRecords)
+        if (hcRecords.isNotEmpty()) client.insertRecords(hcRecords)
     }
 
     actual override suspend fun writeDistance(samples: List<DistanceSample>) {

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
@@ -36,10 +36,16 @@ object HealthDataNormalizer {
         return seconds in 946_684_800L..4_102_444_800L
     }
 
-    fun normalizeHeartRate(samples: List<HeartRateSample>): List<HeartRateSample> {
+    private fun usablePoint(epochSec: Long, nowSec: Long): Boolean =
+        isPlausibleEpochSeconds(epochSec) && HealthTimePolicy.isNotFuture(epochSec, nowSec)
+
+    fun normalizeHeartRate(
+        samples: List<HeartRateSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<HeartRateSample> {
         return samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (s.bpm !in 20..250) return@mapNotNull null
             HeartRateSample(timestamp = t, bpm = s.bpm, tzIn15Min = s.tzIn15Min)
         }
@@ -50,10 +56,13 @@ object HealthDataNormalizer {
             .sortedBy { it.timestamp }
     }
 
-    fun normalizeSpO2(samples: List<SpO2Sample>): List<SpO2Sample> {
+    fun normalizeSpO2(
+        samples: List<SpO2Sample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<SpO2Sample> {
         return samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (s.percentage !in 50..100) return@mapNotNull null
             SpO2Sample(timestamp = t, percentage = s.percentage, tzIn15Min = s.tzIn15Min)
         }
@@ -63,10 +72,14 @@ object HealthDataNormalizer {
             .sortedBy { it.timestamp }
     }
 
-    fun normalizeSteps(records: List<StepsRecord>): List<StepsRecord> {
+    fun normalizeSteps(
+        records: List<StepsRecord>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<StepsRecord> {
         return records.mapNotNull { r ->
             val ts = r.date.toLongOrNull()?.let { toEpochSeconds(it) } ?: return@mapNotNull null
-            if (!isPlausibleEpochSeconds(ts)) return@mapNotNull null
+            // Hour bucket start must not be in the future (HC interval start).
+            if (!usablePoint(ts, nowEpochSeconds)) return@mapNotNull null
             if (r.steps <= 0 || r.steps > 200_000) return@mapNotNull null
             StepsRecord(
                 date = ts.toString(),
@@ -83,37 +96,47 @@ object HealthDataNormalizer {
             .sortedBy { it.date.toLong() }
     }
 
-    fun normalizeSleep(sessions: List<SleepSession>): List<SleepSession> {
+    fun normalizeSleep(
+        sessions: List<SleepSession>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<SleepSession> {
         return sessions.mapNotNull { session ->
             val start = toEpochSeconds(session.startTime)
-            val end = toEpochSeconds(session.endTime)
-            if (!isPlausibleEpochSeconds(start) || !isPlausibleEpochSeconds(end)) return@mapNotNull null
-            if (end <= start) return@mapNotNull null
+            val endRaw = toEpochSeconds(session.endTime)
+            if (!isPlausibleEpochSeconds(start)) return@mapNotNull null
+            val clamped = HealthTimePolicy.clampInterval(start, endRaw, nowEpochSeconds)
+                ?: return@mapNotNull null
+            val (clampedStart, end) = clamped
             val stages = session.stages.mapNotNull { stage ->
                 val s = toEpochSeconds(stage.startTime)
                 val e = toEpochSeconds(stage.endTime)
                 if (e <= s) return@mapNotNull null
-                if (s < start || e > end) return@mapNotNull null
+                if (s < clampedStart || e > end) return@mapNotNull null
+                if (!HealthTimePolicy.isNotFuture(e, nowEpochSeconds)) return@mapNotNull null
                 SleepStage(startTime = s, endTime = e, stage = stage.stage)
             }
                 .sortedBy { it.startTime }
                 .associateBy { it.startTime }
                 .values
                 .sortedBy { it.startTime }
-            val inBedStart = toEpochSeconds(session.inBedStart).takeIf { isPlausibleEpochSeconds(it) } ?: start
-            val inBedEnd = toEpochSeconds(session.inBedEnd).takeIf { isPlausibleEpochSeconds(it) } ?: end
+            val inBedStart = toEpochSeconds(session.inBedStart)
+                .takeIf { isPlausibleEpochSeconds(it) && it <= end } ?: clampedStart
+            val inBedEnd = toEpochSeconds(session.inBedEnd)
+                .takeIf { isPlausibleEpochSeconds(it) }
+                ?.let { minOf(it, end) }
+                ?: end
             SleepSession(
-                startTime = start,
+                startTime = clampedStart,
                 endTime = end,
                 inBedStart = inBedStart,
-                inBedEnd = inBedEnd,
+                inBedEnd = maxOf(inBedStart + 1, inBedEnd),
                 stages = stages,
                 avgHrvMs = session.avgHrvMs?.takeIf { it in 5..300 },
                 minHrvMs = session.minHrvMs?.takeIf { it in 5..300 },
                 maxHrvMs = session.maxHrvMs?.takeIf { it in 5..300 },
                 hrvAnalysisTimeSec = session.hrvAnalysisTimeSec
                     ?.let { toEpochSeconds(it) }
-                    ?.takeIf { isPlausibleEpochSeconds(it) },
+                    ?.takeIf { usablePoint(it, nowEpochSeconds) },
                 tzIn15Min = session.tzIn15Min,
             )
         }
@@ -123,10 +146,13 @@ object HealthDataNormalizer {
             .sortedBy { it.startTime }
     }
 
-    fun normalizeHrv(samples: List<HrvSample>): List<HrvSample> =
+    fun normalizeHrv(
+        samples: List<HrvSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<HrvSample> =
         samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (s.hrvMs !in 5.0..300.0) return@mapNotNull null
             HrvSample(timestamp = t, hrvMs = s.hrvMs, tzIn15Min = s.tzIn15Min)
         }
@@ -147,15 +173,19 @@ object HealthDataNormalizer {
         else -> "unknown"
     }
 
-    fun normalizeDistance(samples: List<DistanceSample>): List<DistanceSample> =
+    fun normalizeDistance(
+        samples: List<DistanceSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<DistanceSample> =
         samples.mapNotNull { s ->
             val start = toEpochSeconds(s.startTime)
-            val end = toEpochSeconds(s.endTime)
-            if (!isPlausibleEpochSeconds(start) || end <= start) return@mapNotNull null
+            val endRaw = toEpochSeconds(s.endTime)
+            val clamped = HealthTimePolicy.clampInterval(start, endRaw, nowEpochSeconds)
+                ?: return@mapNotNull null
             if (s.meters <= 0 || s.meters > 500_000) return@mapNotNull null
             DistanceSample(
-                startTime = start,
-                endTime = end,
+                startTime = clamped.first,
+                endTime = clamped.second,
                 meters = s.meters,
                 tzIn15Min = s.tzIn15Min,
             )
@@ -165,15 +195,19 @@ object HealthDataNormalizer {
             .map { (_, group) -> group.maxBy { it.meters } }
             .sortedBy { it.startTime }
 
-    fun normalizeActiveCalories(samples: List<ActiveCaloriesSample>): List<ActiveCaloriesSample> =
+    fun normalizeActiveCalories(
+        samples: List<ActiveCaloriesSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<ActiveCaloriesSample> =
         samples.mapNotNull { s ->
             val start = toEpochSeconds(s.startTime)
-            val end = toEpochSeconds(s.endTime)
-            if (!isPlausibleEpochSeconds(start) || end <= start) return@mapNotNull null
+            val endRaw = toEpochSeconds(s.endTime)
+            val clamped = HealthTimePolicy.clampInterval(start, endRaw, nowEpochSeconds)
+                ?: return@mapNotNull null
             if (s.kilocalories <= 0 || s.kilocalories > 50_000) return@mapNotNull null
             ActiveCaloriesSample(
-                startTime = start,
-                endTime = end,
+                startTime = clamped.first,
+                endTime = clamped.second,
                 kilocalories = s.kilocalories,
                 tzIn15Min = s.tzIn15Min,
             )
@@ -183,10 +217,13 @@ object HealthDataNormalizer {
             .map { (_, group) -> group.maxBy { it.kilocalories } }
             .sortedBy { it.startTime }
 
-    fun normalizeWeight(measurements: List<WeightMeasurement>): List<WeightMeasurement> =
+    fun normalizeWeight(
+        measurements: List<WeightMeasurement>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<WeightMeasurement> =
         measurements.mapNotNull { m ->
             val t = toEpochSeconds(m.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (m.weightKg !in 1.0..500.0) return@mapNotNull null
             val fat = m.bodyFatPercent?.takeIf { it in 1.0..70.0 }
             WeightMeasurement(
@@ -204,14 +241,19 @@ object HealthDataNormalizer {
             .values
             .sortedBy { it.timestamp }
 
-    fun normalizeWorkouts(sessions: List<WorkoutSession>): List<WorkoutSession> =
+    fun normalizeWorkouts(
+        sessions: List<WorkoutSession>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<WorkoutSession> =
         sessions.mapNotNull { w ->
             val start = toEpochSeconds(w.startTime)
-            val end = toEpochSeconds(w.endTime)
-            if (!isPlausibleEpochSeconds(start) || end <= start) return@mapNotNull null
+            val endRaw = toEpochSeconds(w.endTime)
+            val clamped = HealthTimePolicy.clampInterval(start, endRaw, nowEpochSeconds)
+                ?: return@mapNotNull null
+            val end = clamped.second
             if (end - start > 24 * 3600) return@mapNotNull null
             val cleaned = WorkoutSession(
-                startTime = start,
+                startTime = clamped.first,
                 endTime = end,
                 activityType = w.activityType.ifBlank { "workout" },
                 distanceMeters = w.distanceMeters?.takeIf { it > 0 },
@@ -325,10 +367,13 @@ object HealthDataNormalizer {
             .distinctBy { it.timeSec }
     }
 
-    fun normalizeBloodPressure(samples: List<BloodPressureSample>): List<BloodPressureSample> =
+    fun normalizeBloodPressure(
+        samples: List<BloodPressureSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<BloodPressureSample> =
         samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (s.systolicMmhg !in 60..250 || s.diastolicMmhg !in 30..150) return@mapNotNull null
             if (s.diastolicMmhg >= s.systolicMmhg) return@mapNotNull null
             BloodPressureSample(
@@ -344,10 +389,13 @@ object HealthDataNormalizer {
             .values
             .sortedBy { it.timestamp }
 
-    fun normalizeTemperature(samples: List<TemperatureSample>): List<TemperatureSample> =
+    fun normalizeTemperature(
+        samples: List<TemperatureSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<TemperatureSample> =
         samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             val body = s.bodyCelsius?.takeIf { it in 30.0..45.0 }
             val skin = s.skinCelsius?.takeIf { it in 20.0..45.0 }
             if (body == null && skin == null) return@mapNotNull null
@@ -363,10 +411,13 @@ object HealthDataNormalizer {
             .values
             .sortedBy { it.timestamp }
 
-    fun normalizeVo2Max(samples: List<Vo2MaxSample>): List<Vo2MaxSample> =
+    fun normalizeVo2Max(
+        samples: List<Vo2MaxSample>,
+        nowEpochSeconds: Long = HealthTimePolicy.nowEpochSeconds(),
+    ): List<Vo2MaxSample> =
         samples.mapNotNull { s ->
             val t = toEpochSeconds(s.timestamp)
-            if (!isPlausibleEpochSeconds(t)) return@mapNotNull null
+            if (!usablePoint(t, nowEpochSeconds)) return@mapNotNull null
             if (s.mlPerKgMin !in 5.0..100.0) return@mapNotNull null
             Vo2MaxSample(timestamp = t, mlPerKgMin = s.mlPerKgMin, tzIn15Min = s.tzIn15Min)
         }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthTimePolicy.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthTimePolicy.kt
@@ -1,0 +1,43 @@
+package com.bettermifitness.sync.health
+
+import kotlin.time.Clock
+
+/**
+ * Health Connect / HealthKit absolute-time rules:
+ * - Zone offset is for civil display only.
+ * - Record Instant must not be after "now" (HC rejects with TIME_IN_FUTURE).
+ *
+ * See issue #10: daily resting HR at UTC midnight can still be in the future for
+ * users east of UTC early in their local morning.
+ */
+object HealthTimePolicy {
+
+    /** Allow small device/Mi clock skew before treating a sample as future. */
+    const val CLOCK_SKEW_SECONDS: Long = 120L
+
+    fun nowEpochSeconds(clock: Clock = Clock.System): Long = clock.now().epochSeconds
+
+    /** True if [epochSec] is acceptable for a point-in-time health write. */
+    fun isNotFuture(
+        epochSec: Long,
+        nowSec: Long,
+        skewSec: Long = CLOCK_SKEW_SECONDS,
+    ): Boolean = epochSec <= nowSec + skewSec
+
+    /**
+     * Clamps [end] to [nowSec]+skew when the interval is still open / slightly future.
+     * Drops the interval if [start] is in the future or end would not be after start.
+     */
+    fun clampInterval(
+        start: Long,
+        end: Long,
+        nowSec: Long,
+        skewSec: Long = CLOCK_SKEW_SECONDS,
+    ): Pair<Long, Long>? {
+        val maxAllowed = nowSec + skewSec
+        if (start > maxAllowed) return null
+        val clampedEnd = minOf(end, maxAllowed)
+        if (clampedEnd <= start) return null
+        return start to clampedEnd
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthTimePolicyTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthTimePolicyTest.kt
@@ -1,0 +1,83 @@
+package com.bettermifitness.sync.health
+
+import com.bettermifitness.sync.data.api.HeartRateSample
+import com.bettermifitness.sync.data.api.StepsRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class HealthTimePolicyTest {
+
+    @Test
+    fun isNotFuture_allowsPastAndPresent() {
+        val now = 1_700_000_000L
+        assertTrue(HealthTimePolicy.isNotFuture(now, now))
+        assertTrue(HealthTimePolicy.isNotFuture(now - 1, now))
+        assertTrue(HealthTimePolicy.isNotFuture(now + 60, now)) // within skew
+    }
+
+    @Test
+    fun isNotFuture_rejectsBeyondSkew() {
+        val now = 1_700_000_000L
+        assertFalse(HealthTimePolicy.isNotFuture(now + HealthTimePolicy.CLOCK_SKEW_SECONDS + 1, now))
+    }
+
+    @Test
+    fun clampInterval_clampsOpenEnd() {
+        val now = 1_700_000_500L
+        val start = 1_700_000_000L
+        val end = start + 3599
+        val clamped = HealthTimePolicy.clampInterval(start, end, now)
+        assertNotNull(clamped)
+        assertEquals(start, clamped.first)
+        assertEquals(now + HealthTimePolicy.CLOCK_SKEW_SECONDS, clamped.second)
+    }
+
+    @Test
+    fun clampInterval_dropsFutureStart() {
+        val now = 1_700_000_000L
+        assertNull(HealthTimePolicy.clampInterval(now + 10_000, now + 20_000, now))
+    }
+
+    /**
+     * Issue #10: GMT+3 at 02:24 local = still 23:24 previous day UTC.
+     * RHR sample at 00:00 UTC of "today" is in the future as absolute Instant.
+     */
+    @Test
+    fun normalizeHeartRate_dropsIssue10FutureRestingHr() {
+        val nowSec = Instant.parse("2026-08-07T23:24:03Z").epochSeconds
+        val futureMidnightUtc = Instant.parse("2026-08-08T00:00:00Z").epochSeconds
+        val pastMidnightUtc = Instant.parse("2026-08-07T00:00:00Z").epochSeconds
+
+        val out = HealthDataNormalizer.normalizeHeartRate(
+            listOf(
+                HeartRateSample(timestamp = futureMidnightUtc, bpm = 55),
+                HeartRateSample(timestamp = pastMidnightUtc, bpm = 58),
+            ),
+            nowEpochSeconds = nowSec,
+        )
+        assertEquals(1, out.size)
+        assertEquals(pastMidnightUtc, out[0].timestamp)
+        assertEquals(58, out[0].bpm)
+    }
+
+    @Test
+    fun normalizeSteps_dropsFutureHourStart() {
+        val nowSec = Instant.parse("2026-08-07T23:24:03Z").epochSeconds
+        val futureHour = Instant.parse("2026-08-08T00:00:00Z").epochSeconds
+        val pastHour = Instant.parse("2026-08-07T00:00:00Z").epochSeconds
+        val out = HealthDataNormalizer.normalizeSteps(
+            listOf(
+                StepsRecord(date = futureHour.toString(), steps = 100),
+                StepsRecord(date = pastHour.toString(), steps = 50),
+            ),
+            nowEpochSeconds = nowSec,
+        )
+        assertEquals(1, out.size)
+        assertEquals(pastHour.toString(), out[0].date)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes https://github.com/ilyasaftr/better-mi-fitness-sync/issues/10

Health Connect validates **absolute Instant**, not civil time. Zone offset alone cannot legalize a future Instant. Early local morning (e.g. GMT+3) often receives resting HR at `YYYY-MM-DDT00:00:00Z`, which is still in the future in UTC.

### Changes
- `HealthTimePolicy`: not-future check + interval clamp (+120s skew)
- Apply across `HealthDataNormalizer` (RHR/HR, steps, sleep, workouts, etc.)
- Android steps: clamp hour `endTime` to `Instant.now()`
- Unit tests for issue #10 timestamps

Timezone / Mi offset handling is unchanged (still required by HC docs for civil display).

## Test plan
- [x] `./gradlew detekt`
- [x] `./gradlew :composeApp:iosSimulatorArm64Test`
- [ ] Device: early morning sync with RHR enabled in +offset TZ