### PR TITLE
fix: clarify sync options and home status copy

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeScreen.kt
@@ -194,9 +194,11 @@ fun HomeScreen(onSyncClick: () -> Unit, onSettingsClick: () -> Unit, onLogout: (
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         StatusChip(
                             label = if (state.enabledMetricsCount == 0) {
-                                "No items"
+                                "No metrics"
+                            } else if (state.enabledMetricsCount == 1) {
+                                "1 metric"
                             } else {
-                                "${state.enabledMetricsCount} items"
+                                "${state.enabledMetricsCount} metrics"
                             },
                             tone = if (state.enabledMetricsCount == 0) {
                                 StatusTone.Warning
@@ -209,7 +211,7 @@ fun HomeScreen(onSyncClick: () -> Unit, onSettingsClick: () -> Unit, onLogout: (
                             tone = StatusTone.Neutral,
                         )
                         StatusChip(
-                            label = if (state.autoSync) "Auto on" else "Manual only",
+                            label = if (state.autoSync) "Auto-sync on" else "Manual",
                             tone = if (state.autoSync) StatusTone.Success else StatusTone.Neutral,
                         )
                     }
@@ -347,7 +349,7 @@ private fun buildSetupHint(state: HomeUiState): String {
         state.autoSync ->
             "Syncs $range. Auto-sync runs in the background when possible."
         else ->
-            "Syncs $range. Change items or auto-sync in Settings."
+            "Syncs $range. Change metrics or auto-sync in Settings."
     }
 }
 

--- a/iosApp/iosApp/SyncBetterMiFitnessIntent.swift
+++ b/iosApp/iosApp/SyncBetterMiFitnessIntent.swift
@@ -37,7 +37,7 @@ struct SyncBetterMiFitnessIntent: AppIntent {
         case BackgroundSync.shared.STATUS_PARTIAL_SUCCESS:
             return IntentDialog("Sync finished with some metrics failed. Open the app for details.")
         case BackgroundSync.shared.STATUS_SKIPPED:
-            return IntentDialog("Nothing to sync (no data types enabled).")
+            return IntentDialog("Nothing to sync (no metrics enabled).")
         case BackgroundSync.shared.STATUS_NOT_LOGGED_IN:
             return IntentDialog("You’re not signed in. Open Better Mi Fitness Sync, sign in, then try again.")
         case BackgroundSync.shared.STATUS_HEALTH_UNAVAILABLE:

--- a/iosApp/iosApp/Views/HomeView.swift
+++ b/iosApp/iosApp/Views/HomeView.swift
@@ -121,15 +121,15 @@ struct HomeView: View {
                     ? "Allow access to \(s.healthServiceName)"
                     : s.healthStatusTitle,
                 detail: s.healthStatusDetail.isEmpty
-                    ? "Grant write access so this app can transfer data into \(s.healthServiceName)."
+                    ? "Grant write access so this app can write data to \(s.healthServiceName)."
                     : s.healthStatusDetail,
                 accent: Brand.danger
             )
         }
         if s.enabledMetricsCount == 0 {
             return BlockingBanner(
-                title: "Nothing selected to transfer",
-                detail: "Choose metric types and range in Settings. Viewed data lives in \(s.healthServiceName).",
+                title: "Nothing selected to sync",
+                detail: "Choose metrics and range in Settings. Viewed data lives in \(s.healthServiceName).",
                 accent: Brand.caution
             )
         }
@@ -235,12 +235,12 @@ struct HomeView: View {
         if s.enabledMetricsCount == 0 {
             return "None selected"
         }
-        let types = s.enabledMetricsCount == 1
-            ? "1 type"
-            : "\(s.enabledMetricsCount) types"
+        let metrics = s.enabledMetricsCount == 1
+            ? "1 metric"
+            : "\(s.enabledMetricsCount) metrics"
         let days = s.rangeDays == 1 ? "1 day" : "\(s.rangeDays) days"
-        let auto = s.autoSync ? "Auto on" : "Manual"
-        return "\(types) · \(days) · \(auto)"
+        let auto = s.autoSync ? "Auto-sync on" : "Manual"
+        return "\(metrics) · \(days) · \(auto)"
     }
 
     /// Settings-style row: matched rounded icon badges + title/detail stack.
@@ -313,7 +313,7 @@ struct HomeView: View {
                 )
                 Divider().padding(.leading, 14)
                 footnoteRow(
-                    title: "Background",
+                    title: "Background sync",
                     value: backgroundValue,
                     valueColor: store.state.lastBackgroundIsError ? Brand.danger : Brand.secondaryLabel
                 )
@@ -327,7 +327,7 @@ struct HomeView: View {
     private var lastSyncValue: String {
         let s = store.state
         if s.isSyncing {
-            return "In progress"
+            return "Syncing…"
         }
         let when = s.lastSyncLabel
         if when == "Never" {

--- a/iosApp/iosApp/Views/SettingsView.swift
+++ b/iosApp/iosApp/Views/SettingsView.swift
@@ -85,7 +85,7 @@ struct SettingsView: View {
             Section("Status") {
                 // Keep rows minimal — titles/details live on Home / Sync.
                 LabeledContent("Last sync", value: store.state.lastSyncLabel)
-                LabeledContent("Last background", value: store.state.lastBackgroundSyncLabel)
+                LabeledContent("Last background sync", value: store.state.lastBackgroundSyncLabel)
             }
 
             if store.state.showShortcutsHelp {


### PR DESCRIPTION
Clarify home and settings labels for sync options (metrics, auto-sync, background sync).

Also align Compose home chips and Shortcuts empty-state wording.