### PR TITLE
fix: map Mi deep and light sleep stages correctly

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
@@ -504,18 +504,14 @@ actual class HealthWriter(private val context: Context) : HealthStore {
         HealthConnectPermissionBridge.openHealthConnect?.invoke()
     }
 
-    /**
-     * Mi Fitness sleep states: 2=light/core, 3=deep, 4=REM, 5=awake
-     * (same mapping as iOS HealthWriter).
-     */
-    private fun mapSleepStage(stage: Int): Int {
-        return when (stage) {
-            5, 1 -> SleepSessionRecord.STAGE_TYPE_AWAKE
-            2 -> SleepSessionRecord.STAGE_TYPE_LIGHT
-            3 -> SleepSessionRecord.STAGE_TYPE_DEEP
-            4 -> SleepSessionRecord.STAGE_TYPE_REM
-            else -> SleepSessionRecord.STAGE_TYPE_UNKNOWN
+    /** Uses the shared raw Mi state mapping so Android and iOS stay consistent. */
+    private fun mapSleepStage(stage: Int): Int =
+        when (HealthDataNormalizer.miSleepStageKind(stage)) {
+            HealthDataNormalizer.MiSleepStageKind.AWAKE -> SleepSessionRecord.STAGE_TYPE_AWAKE
+            HealthDataNormalizer.MiSleepStageKind.DEEP -> SleepSessionRecord.STAGE_TYPE_DEEP
+            HealthDataNormalizer.MiSleepStageKind.LIGHT -> SleepSessionRecord.STAGE_TYPE_LIGHT
+            HealthDataNormalizer.MiSleepStageKind.REM -> SleepSessionRecord.STAGE_TYPE_REM
+            HealthDataNormalizer.MiSleepStageKind.UNKNOWN -> SleepSessionRecord.STAGE_TYPE_UNKNOWN
         }
-    }
 
 }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/Models.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/Models.kt
@@ -91,7 +91,7 @@ data class SleepSession(
 data class SleepStage(
     val startTime: Long,
     val endTime: Long,
-    val stage: Int, // 2=light/core, 3=deep, 4=REM, 5=awake (Mi codes)
+    val stage: Int, // 2=deep, 3=light/core, 4=REM, 5=awake (Mi codes)
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthDataNormalizer.kt
@@ -162,15 +162,25 @@ object HealthDataNormalizer {
             .sortedBy { it.timestamp }
 
     /**
-     * Mi Fitness sleep states → platform-neutral labels for tests.
-     * 2=light/core, 3=deep, 4=REM, 5=awake
+     * Raw Mi Fitness stages, verified against its aggregate duration fields:
+     * state 2=deep, 3=light/core, 4=REM, and 5 (or legacy 1)=awake.
      */
-    fun miSleepStageLabel(stage: Int): String = when (stage) {
-        5, 1 -> "awake"
-        2 -> "light"
-        3 -> "deep"
-        4 -> "rem"
-        else -> "unknown"
+    enum class MiSleepStageKind { AWAKE, DEEP, LIGHT, REM, UNKNOWN }
+
+    fun miSleepStageKind(stage: Int): MiSleepStageKind = when (stage) {
+        5, 1 -> MiSleepStageKind.AWAKE
+        2 -> MiSleepStageKind.DEEP
+        3 -> MiSleepStageKind.LIGHT
+        4 -> MiSleepStageKind.REM
+        else -> MiSleepStageKind.UNKNOWN
+    }
+
+    fun miSleepStageLabel(stage: Int): String = when (miSleepStageKind(stage)) {
+        MiSleepStageKind.AWAKE -> "awake"
+        MiSleepStageKind.DEEP -> "deep"
+        MiSleepStageKind.LIGHT -> "light"
+        MiSleepStageKind.REM -> "rem"
+        MiSleepStageKind.UNKNOWN -> "unknown"
     }
 
     fun normalizeDistance(

--- a/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthDataNormalizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bettermifitness/sync/health/HealthDataNormalizerTest.kt
@@ -124,12 +124,15 @@ class HealthDataNormalizerTest {
     }
 
     @Test
-    fun miSleepStageLabels_matchMiCodes() {
-        assertEquals("light", HealthDataNormalizer.miSleepStageLabel(2))
-        assertEquals("deep", HealthDataNormalizer.miSleepStageLabel(3))
-        assertEquals("rem", HealthDataNormalizer.miSleepStageLabel(4))
-        assertEquals("awake", HealthDataNormalizer.miSleepStageLabel(5))
-        assertTrue(HealthDataNormalizer.miSleepStageLabel(99) == "unknown")
+    fun miSleepStageCodes_matchMiPayloadAggregates() {
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.DEEP, HealthDataNormalizer.miSleepStageKind(2))
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.LIGHT, HealthDataNormalizer.miSleepStageKind(3))
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.REM, HealthDataNormalizer.miSleepStageKind(4))
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.AWAKE, HealthDataNormalizer.miSleepStageKind(5))
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.AWAKE, HealthDataNormalizer.miSleepStageKind(1))
+        assertEquals(HealthDataNormalizer.MiSleepStageKind.UNKNOWN, HealthDataNormalizer.miSleepStageKind(99))
+        assertEquals("deep", HealthDataNormalizer.miSleepStageLabel(2))
+        assertEquals("light", HealthDataNormalizer.miSleepStageLabel(3))
     }
 
     @Test

--- a/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
@@ -140,13 +140,12 @@ actual class HealthWriter : HealthStore {
             val stageSamples = session.stages.map { stage ->
                 val start = NSDate.dateWithTimeIntervalSince1970(stage.startTime.toDouble())
                 val end = NSDate.dateWithTimeIntervalSince1970(stage.endTime.toDouble())
-                val value = when (stage.stage) {
-                    // Mi Fitness sleep states: 2=light/core, 3=deep, 4=REM, 5=awake
-                    5 -> HKCategoryValueSleepAnalysisAwake
-                    3 -> HKCategoryValueSleepAnalysisAsleepDeep
-                    4 -> HKCategoryValueSleepAnalysisAsleepREM
-                    2 -> HKCategoryValueSleepAnalysisAsleepCore
-                    else -> HKCategoryValueSleepAnalysisAsleepCore
+                val value = when (HealthDataNormalizer.miSleepStageKind(stage.stage)) {
+                    HealthDataNormalizer.MiSleepStageKind.AWAKE -> HKCategoryValueSleepAnalysisAwake
+                    HealthDataNormalizer.MiSleepStageKind.DEEP -> HKCategoryValueSleepAnalysisAsleepDeep
+                    HealthDataNormalizer.MiSleepStageKind.LIGHT -> HKCategoryValueSleepAnalysisAsleepCore
+                    HealthDataNormalizer.MiSleepStageKind.REM -> HKCategoryValueSleepAnalysisAsleepREM
+                    HealthDataNormalizer.MiSleepStageKind.UNKNOWN -> HKCategoryValueSleepAnalysisAsleepCore
                 }
                 HKCategorySample.categorySampleWithType(
                     type = sleepType,

--- a/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
@@ -46,6 +46,7 @@ import platform.HealthKit.HKCategoryType
 import platform.HealthKit.HKCategoryValueSleepAnalysisAsleepDeep
 import platform.HealthKit.HKCategoryValueSleepAnalysisAsleepREM
 import platform.HealthKit.HKCategoryValueSleepAnalysisAsleepCore
+import platform.HealthKit.HKCategoryValueSleepAnalysisAsleepUnspecified
 import platform.HealthKit.HKCategoryValueSleepAnalysisAwake
 import platform.HealthKit.HKCategoryValueSleepAnalysisInBed
 import platform.UIKit.UIApplication
@@ -145,7 +146,7 @@ actual class HealthWriter : HealthStore {
                     HealthDataNormalizer.MiSleepStageKind.DEEP -> HKCategoryValueSleepAnalysisAsleepDeep
                     HealthDataNormalizer.MiSleepStageKind.LIGHT -> HKCategoryValueSleepAnalysisAsleepCore
                     HealthDataNormalizer.MiSleepStageKind.REM -> HKCategoryValueSleepAnalysisAsleepREM
-                    HealthDataNormalizer.MiSleepStageKind.UNKNOWN -> HKCategoryValueSleepAnalysisAsleepCore
+                    HealthDataNormalizer.MiSleepStageKind.UNKNOWN -> HKCategoryValueSleepAnalysisAsleepUnspecified
                 }
                 HKCategorySample.categorySampleWithType(
                     type = sleepType,

--- a/iosApp/iosApp/HealthKit/HealthKitBridge.swift
+++ b/iosApp/iosApp/HealthKit/HealthKitBridge.swift
@@ -138,7 +138,7 @@ import HealthKit
         case 2: hkValue = .asleepDeep
         case 3: hkValue = .asleepCore
         case 4: hkValue = .asleepREM
-        default: hkValue = .asleepCore
+        default: hkValue = .asleepUnspecified
         }
 
         let sample = HKCategorySample(type: sleepType, value: hkValue.rawValue,

--- a/iosApp/iosApp/HealthKit/HealthKitBridge.swift
+++ b/iosApp/iosApp/HealthKit/HealthKitBridge.swift
@@ -135,8 +135,8 @@ import HealthKit
         let hkValue: HKCategoryValueSleepAnalysis
         switch value {
         case 1: hkValue = .awake
-        case 2: hkValue = .asleepCore
-        case 3: hkValue = .asleepDeep
+        case 2: hkValue = .asleepDeep
+        case 3: hkValue = .asleepCore
         case 4: hkValue = .asleepREM
         default: hkValue = .asleepCore
         }


### PR DESCRIPTION
Correct raw Mi sleep state 2 to deep and state 3 to light/core on Android and iOS.

Existing incorrectly synced records are intentionally not migrated; users can delete them and re-sync.

Closes #14