### PR TITLE
fix: hide background status in release builds

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/AutoSyncPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/AutoSyncPlatform.android.kt
@@ -1,6 +1,8 @@
 package com.bettermifitness.sync
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.os.Build
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -49,8 +51,26 @@ actual object AutoSyncPlatform {
     }
 
     actual fun backgroundRefreshStatusLabel(): String {
-        return L10n.text(L10n.backgroundAndroidStatus)
+        return if (isDebuggable(requireContext()) || isAndroidEmulator()) {
+            L10n.text(L10n.backgroundAndroidStatus)
+        } else {
+            ""
+        }
     }
+
+    private fun isDebuggable(context: Context): Boolean =
+        context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+
+    private fun isAndroidEmulator(): Boolean =
+        Build.FINGERPRINT.startsWith("generic") ||
+            Build.FINGERPRINT.startsWith("unknown") ||
+            Build.MODEL.contains("google_sdk", ignoreCase = true) ||
+            Build.MODEL.contains("emulator", ignoreCase = true) ||
+            Build.MODEL.contains("android sdk built for", ignoreCase = true) ||
+            Build.MANUFACTURER.contains("genymotion", ignoreCase = true) ||
+            (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")) ||
+            Build.HARDWARE.contains("goldfish", ignoreCase = true) ||
+            Build.HARDWARE.contains("ranchu", ignoreCase = true)
 
     actual fun supportsOpportunisticRefreshTest(): Boolean = false
 

--- a/iosApp/iosApp/BackgroundSyncManager.swift
+++ b/iosApp/iosApp/BackgroundSyncManager.swift
@@ -63,12 +63,13 @@ enum BackgroundSyncManager {
         print("[BGSync] cancelled \(taskIdentifier)")
     }
 
+    /// Debug/simulator-only diagnostic. The OS permission does not indicate this app's Auto-sync state.
     static func backgroundRefreshStatusLabel() -> String {
-        if isDebugRefreshEnabled {
-            #if targetEnvironment(simulator)
-            return L10n.backgroundSimulator
-            #endif
-        }
+        guard isDebugRefreshEnabled else { return "" }
+
+        #if targetEnvironment(simulator)
+        return L10n.backgroundSimulator
+        #else
         switch UIApplication.shared.backgroundRefreshStatus {
         case .available:
             return L10n.backgroundOn
@@ -79,6 +80,7 @@ enum BackgroundSyncManager {
         @unknown default:
             return L10n.backgroundUnknown
         }
+        #endif
     }
 
     /// Runs the same 1-day path as BGAppRefresh (Debug / Simulator only).


### PR DESCRIPTION
## Summary
- hide the Android WorkManager scheduling description in normal physical-device release builds
- retain the Android description for debuggable and emulator builds
- hide the iOS Background App Refresh permission status in normal physical-device release builds, where it can be mistaken for the app's Auto-sync state
- retain iOS diagnostics in Debug and simulator builds

## Validation
- `git diff --check`
- `./gradlew detekt :composeApp:allTests :androidApp:assembleDebug --console=plain`
- `./gradlew :androidApp:assembleRelease --console=plain`
- unsigned arm64 iOS Debug/simulator build
- unsigned arm64 iOS Release/device build
