### PR TITLE
fix: wrap long sync metric labels

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/sync/SyncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/sync/SyncScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -191,7 +191,7 @@ private fun MetricRow(metric: SyncMetric, syncState: SyncState) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(52.dp)
+            .heightIn(min = 52.dp)
             .padding(horizontal = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -206,7 +206,7 @@ private fun MetricRow(metric: SyncMetric, syncState: SyncState) {
             L10n.metric(metric.key),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )

--- a/iosApp/iosApp/Views/SyncView.swift
+++ b/iosApp/iosApp/Views/SyncView.swift
@@ -93,7 +93,7 @@ struct SyncView: View {
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
-    /// Fixed-height row: icon | title (1 line) | trailing status
+    /// Adaptive row: icon | title (up to 2 lines) | trailing status
     private func metricRow(_ row: SyncStore.MetricRow) -> some View {
         HStack(spacing: 12) {
             Image(systemName: MetricSymbol.name(for: row.id))
@@ -104,8 +104,8 @@ struct SyncView: View {
             Text(row.label)
                 .font(.body)
                 .foregroundStyle(Brand.label)
-                .lineLimit(1)
-                .truncationMode(.tail)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .accessibilityLabel(row.label)
 
@@ -119,7 +119,7 @@ struct SyncView: View {
             .frame(minWidth: 88, alignment: .trailing)
         }
         .padding(.horizontal, 14)
-        .frame(height: 52)
+        .frame(minHeight: 52)
         .contentShape(Rectangle())
     }
 


### PR DESCRIPTION
## Summary
- allow Sync metric labels to wrap to two lines on Android and iOS
- change fixed-height metric rows to use a 52dp/pt minimum height
- preserve the complete localized metric labels, including VO2 Max

## Validation
- `git diff --check`
- Build and test validation was not rerun, per request.
