### PR TITLE
feat: proactive 1-day token refresh on app open

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/MiSessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/MiSessionManager.kt
@@ -7,6 +7,9 @@ import com.mifitness.miclient.api.MiDataClient
 import com.mifitness.miclient.auth.MiAuth
 import com.mifitness.miclient.auth.MiAuthException
 import com.mifitness.miclient.auth.MiCredentials
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -116,4 +119,42 @@ class MiSessionManager(
      * @return true if refresh succeeded
      */
     suspend fun refreshSession(): Boolean = refreshSessionDetailed().isSuccess
+
+    /**
+     * Proactive refresh: when the app is opened and the last successful token
+     * refresh/login is older than [threshold] (default 1 day), re-mint
+     * serviceToken via passToken so the 4-5 day Xiaomi expiry never hits
+     * while the app is being used regularly.
+     *
+     * Best-effort: returns null when fresh, otherwise the refresh result.
+     * Callers should ignore TransientFailure and keep the current session.
+     */
+    suspend fun refreshIfStale(
+        threshold: kotlin.time.Duration = 1.days,
+        clock: Clock = Clock.System,
+    ): SessionRefreshResult? {
+        // No session at all — nothing to refresh proactively.
+        val creds = credentialsStore.loadCredentials() ?: return null
+        if (creds.passToken.isBlank() || creds.deviceId.isBlank()) return null
+
+        val lastStr = try {
+            credentialsStore.lastRefreshTime.first()
+        } catch (_: Exception) {
+            null
+        }
+        val now = clock.now()
+        if (lastStr != null) {
+            val last = try {
+                kotlin.time.Instant.parse(lastStr)
+            } catch (_: Exception) {
+                null
+            }
+            if (last != null && now - last < threshold) {
+                return null // fresh — skip network
+            }
+        }
+        // Stale or unknown age (legacy installs where key is missing) → refresh.
+        // refreshSessionDetailed is mutex-protected and persists new timestamp on save.
+        return refreshSessionDetailed()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/CredentialsStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/CredentialsStore.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.mifitness.miclient.auth.MiCredentials
 import com.mifitness.miclient.auth.MiRegion
+import kotlin.time.Clock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -17,6 +18,9 @@ class CredentialsStore(
     private val dataStore: DataStore<Preferences>,
 ) : CredentialsPort {
     override val token: Flow<String?> = dataStore.data.map { it[TOKEN_KEY] }
+
+    override val lastRefreshTime: Flow<String?> =
+        dataStore.data.map { it[LAST_REFRESH_KEY] }
 
     val miUserId: Flow<String?> = dataStore.data.map { it[MI_USER_ID_KEY] }
 
@@ -55,7 +59,13 @@ class CredentialsStore(
             }
             // Drop legacy manual mode key if present
             preferences.remove(REGION_MODE_KEY)
+            // Mark token freshness for proactive 1-day refresh on app open.
+            preferences[LAST_REFRESH_KEY] = Clock.System.now().toString()
         }
+    }
+
+    override suspend fun updateLastRefreshTime(timestamp: String) {
+        dataStore.edit { it[LAST_REFRESH_KEY] = timestamp }
     }
 
     override suspend fun loadCredentials(): MiCredentials? {
@@ -111,6 +121,7 @@ class CredentialsStore(
             preferences.remove(PASS_TOKEN_KEY)
             preferences.remove(DEVICE_ID_KEY)
             preferences.remove(C_USER_ID_KEY)
+            preferences.remove(LAST_REFRESH_KEY)
         }
     }
 
@@ -126,5 +137,6 @@ class CredentialsStore(
         private val PASS_TOKEN_KEY = stringPreferencesKey("pass_token")
         private val DEVICE_ID_KEY = stringPreferencesKey("device_id")
         private val C_USER_ID_KEY = stringPreferencesKey("c_user_id")
+        private val LAST_REFRESH_KEY = stringPreferencesKey("last_token_refresh_time")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/SyncPorts.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/preferences/SyncPorts.kt
@@ -2,12 +2,15 @@ package com.bettermifitness.sync.data.preferences
 
 import com.mifitness.miclient.auth.MiCredentials
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 /** ISP: auth token + credentials used by sync policy. */
 interface CredentialsPort {
     val token: Flow<String?>
+    val lastRefreshTime: Flow<String?> get() = emptyFlow()
     suspend fun loadCredentials(): MiCredentials?
     suspend fun saveCredentials(credentials: MiCredentials)
+    suspend fun updateLastRefreshTime(timestamp: String) {}
 }
 
 /** ISP: sync settings + last-run outcome persistence. */

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/sync/SyncCoordinator.kt
@@ -119,6 +119,29 @@ class SyncCoordinator(
             return notLoggedInOrSkipped(userInitiated, requireAutoSync)
         }
 
+        // Proactive 1-day refresh before any Mi call (covers background + foreground sync).
+        // Best-effort: if it returns NeedsReLogin/NeedsVerification we let the real
+        // sync surface it; TransientFailure is ignored to keep current token.
+        try {
+            // SyncSessionPort may be a fake in tests — only MiSessionManager has this.
+            val mgr = session as? com.bettermifitness.sync.data.MiSessionManager
+            val proactive = mgr?.refreshIfStale()
+            if (proactive is com.bettermifitness.sync.data.SessionRefreshResult.NeedsReLogin ||
+                proactive is com.bettermifitness.sync.data.SessionRefreshResult.NeedsVerification
+            ) {
+                return if (userInitiated && !requireAutoSync) {
+                    SyncOutcome.NotLoggedIn
+                } else {
+                    SyncOutcome.Failed(
+                        message = proactive.userMessage,
+                        retryable = false,
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            // Ignore — fall through to normal sync which will retry on AuthExpired.
+        }
+
         if (!healthAvailability.isAvailable()) {
             return SyncOutcome.HealthUnavailable
         }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/ui/home/HomeViewModel.kt
@@ -155,6 +155,23 @@ class HomeViewModel(
     init {
         loadProfile()
         refreshHealthReadiness()
+        // Proactive 1-day refresh when the app is opened (before 4-5d expiry).
+        viewModelScope.launch {
+            try {
+                val result = session.refreshIfStale()
+                // If proactive refresh succeeded, reload profile so Home shows fresh auth.
+                if (result?.isSuccess == true) {
+                    try {
+                        _profile.value = session.api.getMe()
+                        _profileError.value = null
+                    } catch (_: Exception) {
+                        // Non-fatal — next loadProfile/sync will surface the error.
+                    }
+                }
+            } catch (_: Exception) {
+                // Best-effort: stale refresh must never crash app open.
+            }
+        }
     }
 
     fun loadProfile() {


### PR DESCRIPTION
Refresh serviceToken via passToken when last refresh >1d, on Home open and before every sync, to avoid 4-5d Xiaomi expiry. Persists last_token_refresh_time.