### PR TITLE
feat: two-way weight sync (Health Connect / HealthKit <-> Mi Fitness)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
     <uses-permission android:name="android.permission.health.WRITE_VO2_MAX" />
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
 
-    <!-- Optional reads (future verification / UI) -->
+    <!-- Reads for bidirectional sync (weight) + optional verification -->
+    <uses-permission android:name="android.permission.health.READ_WEIGHT" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_RESTING_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />

--- a/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bettermifitness/sync/health/HealthWriter.android.kt
@@ -18,6 +18,7 @@ import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
+import com.bettermifitness.sync.data.time.MiTimezone
 import androidx.health.connect.client.records.SkinTemperatureRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.SpeedRecord
@@ -33,6 +34,8 @@ import androidx.health.connect.client.units.Percentage
 import androidx.health.connect.client.units.Pressure
 import androidx.health.connect.client.units.Temperature
 import androidx.health.connect.client.units.TemperatureDelta
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
 import com.bettermifitness.sync.data.api.ActiveCaloriesSample
 import com.bettermifitness.sync.data.api.BloodPressureSample
 import com.bettermifitness.sync.data.api.DistanceSample
@@ -87,6 +90,29 @@ actual class HealthWriter(private val context: Context) : HealthStore {
             perms += HealthPermission.getWritePermission(SkinTemperatureRecord::class)
         }
         return perms
+    }
+
+    private fun availableReadPermissions(): Set<String> = setOf(
+        HealthPermission.getReadPermission(WeightRecord::class),
+    )
+
+    private fun availablePermissions(): Set<String> =
+        availableWritePermissions() + availableReadPermissions()
+
+    private fun zoneOffsetToMiUnits(zoneOffset: java.time.ZoneOffset?): Int? {
+        if (zoneOffset == null) return null
+        val seconds = zoneOffset.totalSeconds
+        val inRange = seconds in
+            MiTimezone.MIN_OFFSET_SECONDS..MiTimezone.MAX_OFFSET_SECONDS
+        if (!inRange) return null
+        // 15-minute units
+        return seconds / (15 * 60)
+    }
+
+    private fun isSelfWritten(clientRecordId: String?, packageName: String?): Boolean {
+        if (clientRecordId?.startsWith("mifit-") == true) return true
+        if (packageName != null && packageName == context.packageName) return true
+        return false
     }
 
     actual override suspend fun writeHeartRate(samples: List<HeartRateSample>) {
@@ -453,6 +479,41 @@ actual class HealthWriter(private val context: Context) : HealthStore {
         client.insertRecords(records)
     }
 
+    actual override suspend fun readLatestWeight(): WeightMeasurement? {
+        if (!isAvailable()) return null
+        return try {
+            var latest: WeightRecord? = null
+            var pageToken: String? = null
+            do {
+                val response = client.readRecords(
+                    ReadRecordsRequest(
+                        WeightRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(Instant.EPOCH, Instant.now()),
+                        pageToken = pageToken,
+                    ),
+                )
+                for (r in response.records) {
+                    if (isSelfWritten(r.metadata.clientRecordId, r.metadata.dataOrigin.packageName)) continue
+                    if (latest == null || r.time.isAfter(latest.time)) latest = r
+                }
+                pageToken = response.pageToken
+            } while (pageToken != null)
+            val r = latest ?: return null
+            val ts = r.time.epochSecond
+            // HealthDataNormalizer will filter implausible, but double-check
+            val kg = r.weight.inKilograms
+            if (kg !in 1.0..500.0) return null
+            WeightMeasurement(
+                timestamp = ts,
+                weightKg = kg,
+                bodyFatPercent = null,
+                tzIn15Min = zoneOffsetToMiUnits(r.zoneOffset),
+            ).let { listOf(it) }.let { HealthDataNormalizer.normalizeWeight(it).firstOrNull() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     actual override suspend fun isAvailable(): Boolean {
         return HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
     }
@@ -460,7 +521,7 @@ actual class HealthWriter(private val context: Context) : HealthStore {
     actual override suspend fun hasWritePermissions(): Boolean {
         if (!isAvailable()) return false
         return try {
-            val needed = availableWritePermissions()
+            val needed = availablePermissions()
             if (needed.isEmpty()) return false
             val granted = client.permissionController.getGrantedPermissions()
             needed.all { it in granted }
@@ -472,7 +533,7 @@ actual class HealthWriter(private val context: Context) : HealthStore {
     actual override suspend fun requestPermissions() {
         val launcher = HealthConnectPermissionBridge.requestPermissions
             ?: throw IllegalStateException(L10n.text(L10n.healthPermissionsIncomplete))
-        val needed = availableWritePermissions()
+        val needed = availablePermissions()
         if (needed.isEmpty()) {
             throw Exception(L10n.text(L10n.healthNotAvailable))
         }

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/MiDirectApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/api/MiDirectApi.kt
@@ -211,6 +211,52 @@ class MiDirectApi(private val client: MiDataClient) {
     }
 
     /**
+     * Uploads a single weight measurement to Mi cloud (Health Connect / HealthKit -> Mi).
+     * Uses `data/up_fitness_data` with `phone_id` from [MiDataClient.phoneId] and `sid=xiaomiwear_app_manually`.
+     * Mirrors APK `FitnessDataRequest.uploadFitnessData` + `FitnessDataModel` shape.
+     */
+    suspend fun uploadWeight(
+        measurement: WeightMeasurement,
+        phoneIdOverride: String? = null,
+    ): Boolean {
+        val phoneId = phoneIdOverride?.takeIf { it.isNotBlank() } ?: client.phoneId
+        val sid = "xiaomiwear_app_manually"
+        val tzUnits = measurement.tzIn15Min
+        val offsetSec = tzUnits?.let {
+            com.bettermifitness.sync.data.time.MiTimezone.fromPayloadOrNull(it)?.offsetSeconds()
+        } ?: 0
+        val valueJson = buildString {
+            append("{")
+            append("\"weight\":${measurement.weightKg}")
+            append(",\"time\":${measurement.timestamp}")
+            tzUnits?.let { append(",\"timezone\":$it") }
+            // Body-fat is not uploaded via weight-only sync (Mi has no standalone body-fat input);
+            // keep payload minimal weight + time + timezone.
+            append("}")
+        }
+        val dataList = listOf(
+            mapOf(
+                "sid" to sid,
+                "key" to "weight",
+                "time" to measurement.timestamp,
+                "value" to valueJson,
+                "zone_offset" to offsetSec,
+                "zone_name" to "",
+            ),
+        )
+        val result = client.post(
+            path = "/app/v1/data/up_fitness_data",
+            payload = mapOf(
+                "phone_id" to phoneId,
+                "data_list" to dataList,
+            ),
+        )
+        val obj = result.jsonObject
+        val code = obj["code"]?.jsonPrimitive?.content?.toIntOrNull()
+        return code == null || code == 0
+    }
+
+    /**
      * Fetches user profile (decrypted from Mi's endpoint).
      */
     suspend fun getMe(): MeResponse {

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/data/repository/HealthRepository.kt
@@ -3,12 +3,16 @@ package com.bettermifitness.sync.data.repository
 import com.bettermifitness.sync.data.MiSessionManager
 import com.bettermifitness.sync.data.SessionRefreshResult
 import com.bettermifitness.sync.data.api.HeartRateEntry
+import com.bettermifitness.sync.data.api.WeightMeasurement
 import com.bettermifitness.sync.data.api.WorkoutSession
 import com.bettermifitness.sync.data.parse.MiFitnessParsers
 import com.bettermifitness.sync.data.parse.toRaw
 import com.bettermifitness.sync.data.preferences.SyncPreferences
-import com.bettermifitness.sync.health.HealthSampleWriter
+import com.bettermifitness.sync.health.HealthDataNormalizer
+import com.bettermifitness.sync.health.HealthStore
+import com.bettermifitness.sync.health.HealthTimePolicy
 import com.mifitness.miclient.api.MiApiException
+import kotlin.time.Clock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,10 +44,14 @@ sealed class SyncState {
  * Orchestrates Mi fetch → parse → platform health write.
  * Each metric fails independently; one bad metric does not abort the rest.
  * On [MiApiException.AuthExpired], attempts a single passToken refresh for the whole run.
+ *
+ * Weight is bidirectional latest-only (sparse weigh-ins) — newest timestamp wins
+ * regardless of sync window. Body-fat rides with weight when present but is not
+ * a separate bidirectional metric (Mi has no standalone body-fat input). Other metrics remain window-based.
  */
 class HealthRepository(
     private val session: MiSessionManager,
-    private val healthWriter: HealthSampleWriter,
+    private val healthWriter: HealthStore,
 ) : HealthSyncRunner {
     private val _syncProgress = MutableStateFlow(SyncProgress())
     override val syncProgress: StateFlow<SyncProgress> = _syncProgress.asStateFlow()
@@ -76,7 +84,7 @@ class HealthRepository(
         if ("distance" in enabled) syncDistance(from, to)
         if ("active_calories" in enabled) syncActiveCalories(from, to)
         if ("spo2" in enabled) syncSpO2(from, to)
-        if ("weight" in enabled) syncWeight(from, to)
+        if ("weight" in enabled) syncWeightBidirectional()
         if ("workouts" in enabled) syncWorkouts(from, to)
         if ("blood_pressure" in enabled) syncBloodPressure(from, to)
         if ("temperature" in enabled) syncTemperature(from, to)
@@ -178,14 +186,82 @@ class HealthRepository(
         }
     }
 
-    suspend fun syncWeight(from: String, to: String) {
+    /**
+     * Bidirectional weight sync — latest-only LWW (no sync-window).
+     * Weight is sparse (weekly/monthly) so we compare the single newest record
+     * per platform regardless of [from]/[to]. Newer wins; same timestamp+different
+     * weight with newer timestamp still wins. Loop filtered via HealthStore (mifit-* / packageName).
+     */
+    suspend fun syncWeightBidirectional() {
         runMetric("weight") {
-            val measurements = MiFitnessParsers.parseWeightMeasurements(
-                fetchAllByTime("weight", from, to).map { it.toRaw() },
-            )
-            if (measurements.isNotEmpty()) healthWriter.writeWeight(measurements)
-            measurements.size
+            val miLatest = getMiLatestWeight()
+            val hcLatest = try { healthWriter.readLatestWeight() } catch (_: Exception) { null }
+
+            // Both empty
+            if (miLatest == null && hcLatest == null) return@runMetric 0
+
+            // Only one side has data
+            if (miLatest == null && hcLatest != null) {
+                // HC newer -> Mi
+                val ok = api.uploadWeight(hcLatest)
+                return@runMetric if (ok) 1 else throw IllegalStateException("Mi weight upload failed")
+            }
+            if (miLatest != null && hcLatest == null) {
+                healthWriter.writeWeight(listOf(miLatest))
+                return@runMetric 1
+            }
+
+            // Both present — LWW
+            val mi = miLatest!!
+            val hc = hcLatest!!
+            val deltaSec = hc.timestamp - mi.timestamp
+            val weightDiff = kotlin.math.abs(hc.weightKg - mi.weightKg)
+            // Same instant and effectively same weight -> already synced
+            if (kotlin.math.abs(deltaSec) < 60 && weightDiff < 0.05) return@runMetric 0
+            if (deltaSec > 60) {
+                // HC newer -> Mi (preserve timestamp)
+                val ok = api.uploadWeight(hc)
+                if (!ok) throw IllegalStateException("Mi weight upload failed")
+                1
+            } else if (deltaSec < -60) {
+                // Mi newer -> HC
+                healthWriter.writeWeight(listOf(mi))
+                1
+            } else {
+                // Within 60s threshold but different weight: treat larger timestamp as winner
+                if (hc.timestamp > mi.timestamp) {
+                    val ok = api.uploadWeight(hc)
+                    if (!ok) throw IllegalStateException("Mi weight upload failed")
+                    1
+                } else if (mi.timestamp > hc.timestamp) {
+                    healthWriter.writeWeight(listOf(mi))
+                    1
+                } else {
+                    0
+                }
+            }
         }
+    }
+
+    /** Legacy window-based weight (kept for tests); now delegates to bidirectional. */
+    suspend fun syncWeight(from: String, to: String) { syncWeightBidirectional() }
+
+    private suspend fun getMiLatestWeight(): WeightMeasurement? {
+        // Primary: getLatest (server-side latest regardless of time)
+        val latestViaLatest = try {
+            val res = api.getLatest("weight", limit = 5)
+            val list = MiFitnessParsers.parseWeightMeasurements(res.result?.dataList.orEmpty().map { it.toRaw() })
+            HealthDataNormalizer.normalizeWeight(list).maxByOrNull { it.timestamp }
+        } catch (_: Exception) { null }
+        if (latestViaLatest != null) return latestViaLatest
+        // Fallback: broad by-time window (covers legacy / CN quirks)
+        return try {
+            val nowSec = HealthTimePolicy.nowEpochSeconds()
+            val from = "1970-01-01T00:00:00Z"
+            val to = Clock.System.now().toString()
+            val list = MiFitnessParsers.parseWeightMeasurements(fetchAllByTime("weight", from, to).map { it.toRaw() })
+            HealthDataNormalizer.normalizeWeight(list).maxByOrNull { it.timestamp }
+        } catch (_: Exception) { null }
     }
 
     suspend fun syncWorkouts(from: String, to: String) {

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/di/CommonAppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/di/CommonAppModule.kt
@@ -43,10 +43,11 @@ fun commonAppModule(): Module = module {
     // Platform module registers HealthWriter; bind ISP ports to the same instance.
     single<HealthStore> { get<HealthWriter>() }
     single<HealthSampleWriter> { get<HealthWriter>() }
+    single<com.bettermifitness.sync.health.HealthWeightReader> { get<HealthWriter>() }
     single<HealthAvailability> { get<HealthWriter>() }
     single<HealthPermissionRequester> { get<HealthWriter>() }
 
-    single { HealthRepository(get(), get<HealthSampleWriter>()) }
+    single { HealthRepository(get(), get<HealthStore>()) }
     single<HealthSyncRunner> { get<HealthRepository>() }
     single {
         SyncCoordinator(

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthPorts.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthPorts.kt
@@ -96,5 +96,14 @@ interface HealthPermissionRequester {
     suspend fun requestPermissions()
 }
 
-/** Full platform health façade (writes + availability + permissions). */
-interface HealthStore : HealthSampleWriter, HealthAvailability, HealthPermissionRequester
+/**
+ * ISP: read-only surface for weight latest value (bidirectional sync).
+ * Returns the latest sample regardless of sync window (sparse monthly weigh-ins).
+ */
+interface HealthWeightReader {
+    /** Latest weight from Health Connect / HealthKit, or null if none. Loop-filtered (excludes mifit-*). */
+    suspend fun readLatestWeight(): WeightMeasurement?
+}
+
+/** Full platform health façade (writes + availability + permissions + weight reads). */
+interface HealthStore : HealthSampleWriter, HealthWeightReader, HealthAvailability, HealthPermissionRequester

--- a/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthWriter.kt
+++ b/composeApp/src/commonMain/kotlin/com/bettermifitness/sync/health/HealthWriter.kt
@@ -31,6 +31,7 @@ expect class HealthWriter : HealthStore {
     override suspend fun writeTemperature(samples: List<TemperatureSample>)
     override suspend fun writeVo2Max(samples: List<Vo2MaxSample>)
     override suspend fun writeHrv(samples: List<HrvSample>)
+    override suspend fun readLatestWeight(): WeightMeasurement?
     override suspend fun isAvailable(): Boolean
     override suspend fun hasWritePermissions(): Boolean
     override suspend fun requestPermissions()

--- a/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/bettermifitness/sync/health/HealthWriter.ios.kt
@@ -15,8 +15,13 @@ import com.bettermifitness.sync.data.api.WeightMeasurement
 import com.bettermifitness.sync.data.api.WorkoutSession
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDate
+import platform.Foundation.NSSortDescriptor
 import platform.Foundation.NSURL
 import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.distantPast
+import platform.Foundation.distantFuture
+import platform.HealthKit.HKQuery
+import platform.HealthKit.HKSampleQuery
 import platform.HealthKit.HKCategoryTypeIdentifierSleepAnalysis
 import platform.HealthKit.HKCorrelation
 import platform.HealthKit.HKCorrelationType
@@ -452,6 +457,79 @@ actual class HealthWriter : HealthStore {
         saveSamples(hkSamples)
     }
 
+    actual override suspend fun readLatestWeight(): WeightMeasurement? {
+        val identifier = HKQuantityTypeIdentifierBodyMass ?: return null
+        return readLatestQuantity(identifier)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private suspend fun readLatestQuantity(
+        identifier: String,
+    ): WeightMeasurement? {
+        if (!HKHealthStore.isHealthDataAvailable()) return null
+        val type = HKQuantityType.quantityTypeForIdentifier(identifier) ?: return null
+        // Fetch up to 50 latest to skip self-written records
+        return suspendCoroutine { continuation ->
+            val sort = NSSortDescriptor.sortDescriptorWithKey("startDate", ascending = false)
+            // Use no predicate (null) to fetch all time; predicate API varies across SDKs
+            val predicate = null
+            @Suppress("UNCHECKED_CAST")
+            val query = HKSampleQuery(
+                sampleType = type,
+                predicate = predicate,
+                limit = 50UL,
+                sortDescriptors = listOf(sort),
+            ) { _, results, error ->
+                if (error != null) {
+                    continuation.resume(null)
+                    return@HKSampleQuery
+                }
+                val samples = results as? List<HKQuantitySample> ?: run {
+                    continuation.resume(null)
+                    return@HKSampleQuery
+                }
+                for (sample in samples) {
+                    val meta = sample.metadata
+                    val syncId = meta?.get(HKMetadataKeySyncIdentifier) as? String
+                    if (syncId?.startsWith("mifit-") == true) continue
+                    // Also skip if bundle identifier matches self (HealthKit sourceRevision)
+                    val sourceId = try {
+                        sample.sourceRevision.source.bundleIdentifier
+                    } catch (_: Exception) { null }
+                    // If we can detect self source, skip; but metadata prefix is primary
+                    // Allow any non-self record
+                    val quantity = sample.quantity
+                    val value = try {
+                        val kgUnit = HKUnit.unitFromString("kg")
+                        val kg = quantity.doubleValueForUnit(kgUnit)
+                        if (kg !in 1.0..500.0) continue
+                        kg
+                    } catch (_: Exception) { continue }
+                    val ts = (sample.startDate.timeIntervalSinceReferenceDate +
+                        978307200.0).toLong()
+                    if (!HealthTimePolicy.isNotFuture(ts, HealthTimePolicy.nowEpochSeconds())) {
+                        continue
+                    }
+                    val measurement = WeightMeasurement(
+                        timestamp = ts,
+                        weightKg = value,
+                        tzIn15Min = null,
+                    )
+                    // Normalize via HealthDataNormalizer for plausibility
+                    val normalized = HealthDataNormalizer.normalizeWeight(
+                        listOf(measurement),
+                    ).firstOrNull()
+                    if (normalized != null) {
+                        continuation.resume(normalized)
+                        return@HKSampleQuery
+                    }
+                }
+                continuation.resume(null)
+            }
+            healthStore.executeQuery(query)
+        }
+    }
+
     actual override suspend fun isAvailable(): Boolean {
         return HKHealthStore.isHealthDataAvailable()
     }
@@ -473,10 +551,13 @@ actual class HealthWriter : HealthStore {
         if (types.isEmpty()) {
             throw Exception("No HealthKit types available to request")
         }
+        val readTypes: Set<platform.HealthKit.HKObjectType> = buildSet {
+            HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)?.let { add(it) }
+        }
         suspendCoroutine { continuation ->
             healthStore.requestAuthorizationToShareTypes(
                 typesToShare = types,
-                readTypes = emptySet<platform.HealthKit.HKObjectType>(),
+                readTypes = readTypes,
             ) { _, error ->
                 // Apple’s success flag means the sheet finished — not that types were granted.
                 if (error != null) {

--- a/miclient/src/commonMain/kotlin/com/mifitness/miclient/api/MiDataClient.kt
+++ b/miclient/src/commonMain/kotlin/com/mifitness/miclient/api/MiDataClient.kt
@@ -34,6 +34,9 @@ class MiDataClient(
     /** The regional data host for this user (e.g. "sg.hlth.io.mi.com"). */
     val healthHost: String = buildHealthHost(credentials.region)
 
+    /** Device-scoped phone identifier for fitness data uploads (APK `phoneId`). */
+    val phoneId: String get() = credentials.deviceId.ifBlank { "xiaomiwear_app_manually" }
+
     /**
      * Sends an encrypted POST request and returns the decrypted JSON response.
      *


### PR DESCRIPTION
Adds support for syncing weight between Health Connect / HealthKit and Mi Fitness cloud (latest-only, newest wins).

Closes #24